### PR TITLE
fix: `keywords`  can be `NOT NULL`

### DIFF
--- a/server/src/main/java/de/tum/cit/aet/thesis/entity/Thesis.java
+++ b/server/src/main/java/de/tum/cit/aet/thesis/entity/Thesis.java
@@ -61,7 +61,7 @@ public class Thesis {
     private ThesisVisibility visibility;
 
     @JdbcTypeCode(SqlTypes.ARRAY)
-    @Column(name = "keywords", columnDefinition = "text[]")
+    @Column(name = "keywords", columnDefinition = "text[]", nullable = false)
     private Set<String> keywords = new HashSet<>();
 
     @ManyToOne(fetch = FetchType.LAZY)

--- a/server/src/main/resources/db/changelog/changes/08_theses_keywords_not_null.sql
+++ b/server/src/main/resources/db/changelog/changes/08_theses_keywords_not_null.sql
@@ -1,0 +1,10 @@
+-- liquibase formatted sql
+
+-- changeset frank:theses_keywords_not_null-1
+UPDATE theses
+    SET keywords = ARRAY[]::text[]
+    WHERE keywords IS NULL;
+
+-- changeset frank:theses_keywords_not_null-2
+ALTER TABLE theses
+    ALTER COLUMN keywords SET NOT NULL;

--- a/server/src/main/resources/db/changelog/db.changelog-master.xml
+++ b/server/src/main/resources/db/changelog/db.changelog-master.xml
@@ -11,4 +11,5 @@
     <include file="changes/05_thesis_presentations.sql" relativeToChangelogFile="true" />
     <include file="changes/06_topics.sql" relativeToChangelogFile="true" />
     <include file="changes/07_cleanup.sql" relativeToChangelogFile="true" />
+    <include file="changes/08_theses_keywords_not_null.sql" relativeToChangelogFile="true" />
 </databaseChangeLog>


### PR DESCRIPTION
During evaluating the changes nesssesary to add organisation support (#405), I noticed that the `keywords` field defaults in the database and is null-checked before-insert.
=> this can savely be moved to the default of an empty array

Primary Reason for this PR: Liquibase generates a (slightly misleading) line in the changelog