### PR TITLE
Development: Filter API calls by research group of user

### DIFF
--- a/client/src/components/UserInformationForm/UserInformationForm.tsx
+++ b/client/src/components/UserInformationForm/UserInformationForm.tsx
@@ -38,6 +38,7 @@ const UserInformationForm = (props: IUserInformationFormProps) => {
   const form = useForm<
     Omit<IUpdateUserInformationPayload, 'enrolledAt'> & {
       semester: string
+      researchGroupName: string | null
       customData: Record<string, string>
       declarationOfConsentAccepted: boolean
       avatar: File | undefined
@@ -57,6 +58,7 @@ const UserInformationForm = (props: IUserInformationFormProps) => {
       studyDegree: '',
       studyProgram: '',
       semester: '',
+      researchGroupName: null,
       specialSkills: '',
       projects: '',
       interests: '',
@@ -147,6 +149,7 @@ const UserInformationForm = (props: IUserInformationFormProps) => {
       studyDegree: user?.studyDegree || '',
       studyProgram: user?.studyProgram || '',
       semester: user?.enrolledAt ? enrollmentDateToSemester(user.enrolledAt).toString() : '',
+      researchGroupName: user?.researchGroupName || null,
       specialSkills: user?.specialSkills || '',
       interests: user?.interests || '',
       projects: user?.projects || '',
@@ -314,6 +317,14 @@ const UserInformationForm = (props: IUserInformationFormProps) => {
             {...form.getInputProps('semester')}
           />
         </Group>
+        {user?.researchGroupName && (
+          <Select
+            label='Research Group'
+            data={[user.researchGroupName]}
+            disabled
+            {...form.getInputProps('researchGroupName')}
+          />
+        )}
         {Object.entries(GLOBAL_CONFIG.custom_data).map(([key, value]) => (
           <TextInput
             key={key}

--- a/client/src/hooks/fetcher.ts
+++ b/client/src/hooks/fetcher.ts
@@ -98,7 +98,7 @@ export function useAllTopics() {
       `/v2/topics`,
       {
         method: 'GET',
-        requiresAuth: false,
+        requiresAuth: true,
         params: {
           limit: 1000,
           includeClosed: 'false',

--- a/client/src/pages/LandingPage/LandingPage.tsx
+++ b/client/src/pages/LandingPage/LandingPage.tsx
@@ -14,7 +14,7 @@ const LandingPage = () => {
   return (
     <PublicArea hero={<HeroSection />}>
       <Stack>
-        <TopicsProvider limit={10}>
+        <TopicsProvider limit={10} researchSpecific={false}>
           <Stack gap='xs'>
             <Title order={2}>Open Topics</Title>
             <TopicsTable

--- a/client/src/pages/ReplaceApplicationPage/components/MotivationStep/MotivationStep.tsx
+++ b/client/src/pages/ReplaceApplicationPage/components/MotivationStep/MotivationStep.tsx
@@ -158,7 +158,9 @@ const MotivationStep = (props: IMotivationStepProps) => {
         <Select
           label='Research Group'
           required={true}
-          disabled={loading || !researchGroups || !!mergedTopic}
+          disabled={
+            loading || !researchGroups || !!mergedTopic || researchGroups.totalElements <= 1
+          }
           data={researchGroups?.content.map((researchGroup: IResearchGroup) => ({
             label: researchGroup.name,
             value: researchGroup.id,

--- a/client/src/pages/ReplaceApplicationPage/components/MotivationStep/MotivationStep.tsx
+++ b/client/src/pages/ReplaceApplicationPage/components/MotivationStep/MotivationStep.tsx
@@ -12,6 +12,8 @@ import { GLOBAL_CONFIG } from '../../../../config/global'
 import { IApplication } from '../../../../requests/responses/application'
 import TopicAccordionItem from '../../../../components/TopicAccordionItem/TopicAccordionItem'
 import { formatThesisType } from '../../../../utils/format'
+import { PaginationResponse } from '../../../../requests/responses/pagination'
+import { IResearchGroup } from '../../../../requests/responses/researchGroup'
 
 interface IMotivationStepProps {
   topic: ITopic | undefined
@@ -21,6 +23,7 @@ interface IMotivationStepProps {
 
 interface IMotivationStepForm {
   thesisTitle: string
+  researchGroup: string
   thesisType: string | null
   desiredStartDate: DateValue
   motivation: string
@@ -29,6 +32,7 @@ interface IMotivationStepForm {
 const MotivationStep = (props: IMotivationStepProps) => {
   const { topic, application, onComplete } = props
 
+  const [researchGroups, setResearchGroups] = useState<PaginationResponse<IResearchGroup>>()
   const [loading, setLoading] = useState(false)
 
   const mergedTopic = application?.topic || topic
@@ -37,6 +41,7 @@ const MotivationStep = (props: IMotivationStepProps) => {
     mode: 'controlled',
     initialValues: {
       thesisTitle: '',
+      researchGroup: mergedTopic?.researchGroup.id ?? '',
       thesisType: null,
       desiredStartDate: new Date(),
       motivation: '',
@@ -66,10 +71,45 @@ const MotivationStep = (props: IMotivationStepProps) => {
         motivation: application.motivation,
         desiredStartDate: new Date(application.desiredStartDate),
         thesisType: application.thesisType,
-        thesisTitle: application.thesisTitle || '',
+        thesisTitle: application.thesisTitle ?? '',
       })
     }
   }, [application?.applicationId])
+
+  useEffect(() => {
+    setLoading(true)
+    return doRequest<PaginationResponse<IResearchGroup>>(
+      '/v2/research-groups',
+      {
+        method: 'GET',
+        requiresAuth: true,
+        params: {
+          page: 0,
+          limit: -1,
+        },
+      },
+      (res) => {
+        if (res.ok) {
+          setResearchGroups({
+            ...res.data,
+            content: res.data.content,
+          })
+        } else {
+          showSimpleError(getApiResponseErrorMessage(res))
+
+          setResearchGroups({
+            content: [],
+            totalPages: 0,
+            totalElements: 0,
+            last: true,
+            pageNumber: 0,
+            pageSize: -1,
+          })
+        }
+        setLoading(false)
+      },
+    )
+  }, [])
 
   const onSubmit = async (values: IMotivationStepForm) => {
     setLoading(true)
@@ -82,6 +122,7 @@ const MotivationStep = (props: IMotivationStepProps) => {
           requiresAuth: true,
           data: {
             topicId: mergedTopic?.topicId,
+            researchGroupId: values.researchGroup,
             thesisTitle: values.thesisTitle || null,
             thesisType: values.thesisType,
             desiredStartDate: values.desiredStartDate,
@@ -114,6 +155,17 @@ const MotivationStep = (props: IMotivationStepProps) => {
             {...form.getInputProps('thesisTitle')}
           />
         )}
+        <Select
+          label='Research Group'
+          required={true}
+          disabled={loading || !researchGroups || !!mergedTopic}
+          data={researchGroups?.content.map((researchGroup: IResearchGroup) => ({
+            label: researchGroup.name,
+            value: researchGroup.id,
+          }))}
+          searchable
+          {...form.getInputProps('researchGroup')}
+        />
         <Select
           label='Thesis Type'
           required={true}

--- a/client/src/providers/AuthenticationContext/AuthenticationProvider.tsx
+++ b/client/src/providers/AuthenticationContext/AuthenticationProvider.tsx
@@ -155,7 +155,7 @@ const AuthenticationProvider = (props: PropsWithChildren) => {
       return doRequest<IUser>(
         '/v2/user-info',
         {
-          method: 'POST',
+          method: 'GET',
           requiresAuth: true,
         },
         (res) => {

--- a/client/src/providers/TopicsProvider/TopicsProvider.tsx
+++ b/client/src/providers/TopicsProvider/TopicsProvider.tsx
@@ -9,15 +9,23 @@ interface ITopicsProviderProps {
   includeClosedTopics?: boolean
   limit: number
   hideIfEmpty?: boolean
+  researchSpecific?: boolean
 }
 
 const TopicsProvider = (props: PropsWithChildren<ITopicsProviderProps>) => {
-  const { children, includeClosedTopics = false, limit, hideIfEmpty = false } = props
+  const {
+    children,
+    includeClosedTopics = false,
+    limit,
+    hideIfEmpty = false,
+    researchSpecific = true,
+  } = props
 
   const [topics, setTopics] = useState<PaginationResponse<ITopic>>()
   const [page, setPage] = useState(0)
   const [filters, setFilters] = useState<ITopicsFilters>({
     includeClosed: includeClosedTopics,
+    researchSpecific: researchSpecific,
   })
 
   useEffect(() => {
@@ -27,12 +35,13 @@ const TopicsProvider = (props: PropsWithChildren<ITopicsProviderProps>) => {
       `/v2/topics`,
       {
         method: 'GET',
-        requiresAuth: false,
+        requiresAuth: filters.researchSpecific ? true : false,
         params: {
           page,
           limit,
           type: filters.types?.join(',') || '',
           includeClosed: filters.includeClosed ? 'true' : 'false',
+          onlyOwnResearchGroup: filters.researchSpecific ? 'true' : 'false',
         },
       },
       (res) => {

--- a/client/src/providers/TopicsProvider/context.ts
+++ b/client/src/providers/TopicsProvider/context.ts
@@ -5,6 +5,7 @@ import { PaginationResponse } from '../../requests/responses/pagination'
 export interface ITopicsFilters {
   types?: string[]
   includeClosed?: boolean
+  researchSpecific?: boolean
 }
 
 export interface ITopicsContext {

--- a/client/src/requests/responses/application.ts
+++ b/client/src/requests/responses/application.ts
@@ -1,5 +1,6 @@
 import { ILightUser, IUser } from './user'
 import { ITopic } from './topic'
+import { ILightResearchGroup } from './researchGroup'
 
 export enum ApplicationState {
   NOT_ASSESSED = 'NOT_ASSESSED',
@@ -24,4 +25,5 @@ export interface IApplication {
     reviewedAt: string
   }> | null
   reviewedAt: string | null
+  researchGroup: ILightResearchGroup
 }

--- a/client/src/requests/responses/researchGroup.ts
+++ b/client/src/requests/responses/researchGroup.ts
@@ -1,0 +1,14 @@
+import { ILightUser } from './user'
+
+export interface ILightResearchGroup {
+  id: string
+  head: ILightUser
+  name: string
+}
+
+export interface IResearchGroup extends ILightResearchGroup {
+  abbreviation: string
+  description: string
+  websiteUrl: string
+  campus: string
+}

--- a/client/src/requests/responses/thesis.ts
+++ b/client/src/requests/responses/thesis.ts
@@ -1,3 +1,4 @@
+import { ILightResearchGroup } from './researchGroup'
 import { ILightUser } from './user'
 
 export enum ThesisState {
@@ -42,6 +43,7 @@ export interface IThesis {
   startDate: string | null
   endDate: string | null
   createdAt: string
+  researchGroup: ILightResearchGroup
   students: ILightUser[]
   advisors: ILightUser[]
   supervisors: ILightUser[]

--- a/client/src/requests/responses/topic.ts
+++ b/client/src/requests/responses/topic.ts
@@ -1,3 +1,4 @@
+import { ILightResearchGroup } from './researchGroup'
 import { ILightUser } from './user'
 
 export interface ITopic {
@@ -12,6 +13,7 @@ export interface ITopic {
   updatedAt: string
   createdAt: string
   createdBy: ILightUser
+  researchGroup: ILightResearchGroup
   advisors: ILightUser[]
   supervisors: ILightUser[]
 }

--- a/client/src/requests/responses/user.ts
+++ b/client/src/requests/responses/user.ts
@@ -14,6 +14,7 @@ export interface ILightUser {
 }
 
 export interface IUser extends ILightUser {
+  researchGroupName: string | null
   gender: string | null
   nationality: string | null
   projects: string | null

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -80,7 +80,7 @@ A ready-to-use Postman Collection is included: [`TUMApply API.postman_collection
 ### How to Use
 
 1. Open Postman and click **Import** on the top left.
-2. Upload the provided [`TUMApply API.postman_collection.json`](./Thesis%20Management%20API.
+2. Upload the provided [`TUMApply API.postman_collection.json`](./Thesis%20Management%20API.postman_collection.json).
    postman_collection.json).
 3. The collection will appear in the sidebar.
 4. Start sending requests — OAuth2 authentication will be handled automatically.

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -58,3 +58,31 @@ npm run dev
 ```
 
 Client is served at http://localhost:3000. 
+
+## Postman Collection
+
+A ready-to-use Postman Collection is included: [`TUMApply API.postman_collection.json`](./Thesis%20Management%20API.postman_collection.json).
+
+### Key Features
+
+- ✅ **Pre-configured OAuth2 Authentication**  
+  The collection handles the full OAuth2 flow using Keycloak. When sending a request, Postman 
+  will automatically open a login window (otherwise go to the Collection > Authorization > Click 
+  on "Get New Access Token" at the bottom) if the token is missing or expired. Token refresh is 
+  also handled automatically.
+
+- ✅ **Collection-Level Configuration**  
+  Authentication and common headers are defined at the collection level, so you don't need to configure them for each individual request.
+
+- ✅ **Collection Variables**  
+  Key values like `{{baseUrl}}`, `{{accessToken}}`, `{{clientId}}`, etc. are pre-configured as variables. This makes the collection flexible and easy to adapt to different environments.
+
+### How to Use
+
+1. Open Postman and click **Import** on the top left.
+2. Upload the provided [`TUMApply API.postman_collection.json`](./Thesis%20Management%20API.
+   postman_collection.json).
+3. The collection will appear in the sidebar.
+4. Start sending requests — OAuth2 authentication will be handled automatically.
+
+> 💡 No manual token handling is needed. Just sign in via Keycloak when prompted.

--- a/docs/Thesis Management API.postman_collection.json
+++ b/docs/Thesis Management API.postman_collection.json
@@ -1,0 +1,2592 @@
+{
+	"info": {
+		"_postman_id": "64d700ac-4ad8-437f-b64f-22c82c8332e6",
+		"name": "Thesis Management API",
+		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
+		"_exporter_id": "18638253"
+	},
+	"item": [
+		{
+			"name": "Applications",
+			"item": [
+				{
+					"name": "Specific Application",
+					"item": [
+						{
+							"name": "Get Application",
+							"protocolProfileBehavior": {
+								"disableBodyPruning": true
+							},
+							"request": {
+								"method": "GET",
+								"header": [],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n    \"test\": \"123\"\n}",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "{{baseUrl}}/applications/:application_id",
+									"host": [
+										"{{baseUrl}}"
+									],
+									"path": [
+										"applications",
+										":application_id"
+									],
+									"variable": [
+										{
+											"key": "application_id",
+											"value": ""
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Update Application",
+							"request": {
+								"method": "PUT",
+								"header": [],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n    \"topic_id\": \"e97bb95b-e838-4c8b-9386-a47a71e682f9\",\n    \"thesisTitle\": \"title\",\n    \"thesisType\": \"BACHELOR\",\n    \"desiredStartDate\": {{$timestamp}},\n    \"motivation\": \"motivation\",\n    \"researchGroupId\": \"4d856690-bb2b-4584-b89a-c92a20ffd5d9\"\n}",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "{{baseUrl}}/applications/:application_id",
+									"host": [
+										"{{baseUrl}}"
+									],
+									"path": [
+										"applications",
+										":application_id"
+									],
+									"variable": [
+										{
+											"key": "application_id",
+											"value": "c2706d97-ee87-40ff-a02d-d1beb09048f3",
+											"description": "(Required) "
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Accept Application",
+							"request": {
+								"method": "PUT",
+								"header": [],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n    \"thesisTitle\": \"title\",\n    \"thesisType\": \"BACHELOR\",\n    \"language\": \"ENGLISH\",\n    \"advisorIds\": [\"76638673-ca5e-4000-8f5c-3da377bf0eda\"],\n    \"supervisorIds\": [\"76638673-ca5e-4000-8f5c-3da377bf0eda\"],\n    \"notifyUser\": true,\n    \"closeTopic\": false\n}",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "{{baseUrl}}/applications/:application_id/accept",
+									"host": [
+										"{{baseUrl}}"
+									],
+									"path": [
+										"applications",
+										":application_id",
+										"accept"
+									],
+									"variable": [
+										{
+											"key": "application_id",
+											"value": "c2706d97-ee87-40ff-a02d-d1beb09048f3",
+											"description": "(Required) "
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Comment Application",
+							"request": {
+								"method": "PUT",
+								"header": [],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n    \"comment\": \"Comment\"\n}",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "{{baseUrl}}/applications/:application_id/comment",
+									"host": [
+										"{{baseUrl}}"
+									],
+									"path": [
+										"applications",
+										":application_id",
+										"comment"
+									],
+									"variable": [
+										{
+											"key": "application_id",
+											"value": "c2706d97-ee87-40ff-a02d-d1beb09048f3",
+											"description": "(Required) "
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Reject Application",
+							"request": {
+								"method": "PUT",
+								"header": [],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n    \"reason\": \"TOPIC_FILLED\",\n    \"notifyUser\": true\n}",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "{{baseUrl}}/applications/:application_id/reject",
+									"host": [
+										"{{baseUrl}}"
+									],
+									"path": [
+										"applications",
+										":application_id",
+										"reject"
+									],
+									"variable": [
+										{
+											"key": "application_id",
+											"value": "c2706d97-ee87-40ff-a02d-d1beb09048f3",
+											"description": "(Required) "
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Review Application",
+							"request": {
+								"method": "PUT",
+								"header": [],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n    \"reason\": \"INTERESTED\"\n}",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "{{baseUrl}}/applications/:application_id/review",
+									"host": [
+										"{{baseUrl}}"
+									],
+									"path": [
+										"applications",
+										":application_id",
+										"review"
+									],
+									"variable": [
+										{
+											"key": "application_id",
+											"value": "c2706d97-ee87-40ff-a02d-d1beb09048f3",
+											"description": "(Required) "
+										}
+									]
+								}
+							},
+							"response": []
+						}
+					]
+				},
+				{
+					"name": "Get All Applications",
+					"request": {
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "{{baseUrl}}/applications?fetchAll=true",
+							"host": [
+								"{{baseUrl}}"
+							],
+							"path": [
+								"applications"
+							],
+							"query": [
+								{
+									"key": "search",
+									"value": "\"Test\"",
+									"disabled": true
+								},
+								{
+									"key": "state",
+									"value": "ACCEPTED",
+									"disabled": true
+								},
+								{
+									"key": "topics",
+									"value": "54696a2c-b4f6-432e-a5c8-1d8f190c35bc",
+									"disabled": true
+								},
+								{
+									"key": "types",
+									"value": "Test",
+									"disabled": true
+								},
+								{
+									"key": "previous",
+									"value": "54696a2c-b4f6-432e-a5c8-1d8f190c35bc",
+									"disabled": true
+								},
+								{
+									"key": "includeSuggestedTopics",
+									"value": "true",
+									"disabled": true
+								},
+								{
+									"key": "fetchAll",
+									"value": "true"
+								},
+								{
+									"key": "page",
+									"value": "0",
+									"disabled": true
+								},
+								{
+									"key": "limit",
+									"value": "50",
+									"disabled": true
+								},
+								{
+									"key": "sortBy",
+									"value": "createdAt",
+									"disabled": true
+								},
+								{
+									"key": "sortOrder",
+									"value": "asc",
+									"disabled": true
+								}
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Creates a new application",
+					"request": {
+						"method": "POST",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"topic_id\": \"54696a2c-b4f6-432e-a5c8-1d8f190c35bc\",\n    \"thesisTitle\": \"title\",\n    \"thesisType\": \"BACHELOR\",\n    \"desiredStartDate\": {{$timestamp}},\n    \"motivation\": \"motivation\",\n    \"researchGroupId\": \"4d5c6f1b-6e83-4e5e-9f6a-2657dc724aec\"\n}",
+							"options": {
+								"raw": {
+									"headerFamily": "json",
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{baseUrl}}/applications",
+							"host": [
+								"{{baseUrl}}"
+							],
+							"path": [
+								"applications"
+							]
+						}
+					},
+					"response": []
+				}
+			]
+		},
+		{
+			"name": "Avatars",
+			"item": [
+				{
+					"name": "Get User Avatar",
+					"request": {
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "{{baseUrl}}/avatars/:userId",
+							"host": [
+								"{{baseUrl}}"
+							],
+							"path": [
+								"avatars",
+								":userId"
+							],
+							"variable": [
+								{
+									"key": "userId",
+									"value": "fdde346c-4ad0-4e5a-82b8-93191553e325"
+								}
+							]
+						}
+					},
+					"response": []
+				}
+			]
+		},
+		{
+			"name": "Calendar",
+			"item": [
+				{
+					"name": "Get Calendar",
+					"request": {
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "{{baseUrl}}/calendar/presentations",
+							"host": [
+								"{{baseUrl}}"
+							],
+							"path": [
+								"calendar",
+								"presentations"
+							]
+						}
+					},
+					"response": []
+				}
+			]
+		},
+		{
+			"name": "Keycloak",
+			"item": [
+				{
+					"name": "Access Token",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"const response = pm.response.json();",
+									"const expiresIn = response.expires_in;",
+									"",
+									"pm.environment.set(\"access_token\", response.access_token);",
+									"pm.environment.set(\"refresh_token\", response.refresh_token);",
+									"pm.environment.set(\"access_token_expiry\", Math.floor(Date.now() / 1000) + expiresIn - 10);"
+								],
+								"type": "text/javascript",
+								"packages": {}
+							}
+						}
+					],
+					"request": {
+						"method": "POST",
+						"header": [],
+						"body": {
+							"mode": "urlencoded",
+							"urlencoded": [
+								{
+									"key": "client_id",
+									"value": "{{clientId}}",
+									"type": "text"
+								},
+								{
+									"key": "username",
+									"value": "{{username}}",
+									"type": "text"
+								},
+								{
+									"key": "password",
+									"value": "{{password}}",
+									"type": "text"
+								},
+								{
+									"key": "grant_type",
+									"value": "password",
+									"type": "text"
+								}
+							]
+						},
+						"url": {
+							"raw": "{{baseKeycloakUrl}}/realms/{{realm}}/protocol/openid-connect/token",
+							"host": [
+								"{{baseKeycloakUrl}}"
+							],
+							"path": [
+								"realms",
+								"{{realm}}",
+								"protocol",
+								"openid-connect",
+								"token"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Refresh Token",
+					"request": {
+						"method": "POST",
+						"header": [],
+						"body": {
+							"mode": "urlencoded",
+							"urlencoded": [
+								{
+									"key": "client_id",
+									"value": "{{clientId}}",
+									"type": "text"
+								},
+								{
+									"key": "grant_type",
+									"value": "refresh_token",
+									"type": "text"
+								},
+								{
+									"key": "refresh_token",
+									"value": "{{refreshToken}}",
+									"type": "text"
+								}
+							]
+						},
+						"url": {
+							"raw": "{{baseKeycloakUrl}}/realms/{{realm}}/protocol/openid-connect/token",
+							"host": [
+								"{{baseKeycloakUrl}}"
+							],
+							"path": [
+								"realms",
+								"{{realm}}",
+								"protocol",
+								"openid-connect",
+								"token"
+							]
+						}
+					},
+					"response": []
+				}
+			]
+		},
+		{
+			"name": "Published Presentations",
+			"item": [
+				{
+					"name": "Specific Presentation",
+					"item": [
+						{
+							"name": "Get Presentation",
+							"request": {
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "{{baseUrl}}/published-presentations/:presentationId",
+									"host": [
+										"{{baseUrl}}"
+									],
+									"path": [
+										"published-presentations",
+										":presentationId"
+									],
+									"variable": [
+										{
+											"key": "presentationId",
+											"value": "d0b63a29-cc30-437a-8c8f-0796e91eeff6"
+										}
+									]
+								}
+							},
+							"response": []
+						}
+					]
+				},
+				{
+					"name": "Get All Presentations",
+					"request": {
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "{{baseUrl}}/published-presentations?includeDrafts=true&page=0&limit=50&sortBy=scheduledAt&sortOrder=asc",
+							"host": [
+								"{{baseUrl}}"
+							],
+							"path": [
+								"published-presentations"
+							],
+							"query": [
+								{
+									"key": "includeDrafts",
+									"value": "true"
+								},
+								{
+									"key": "page",
+									"value": "0"
+								},
+								{
+									"key": "limit",
+									"value": "50"
+								},
+								{
+									"key": "sortBy",
+									"value": "scheduledAt"
+								},
+								{
+									"key": "sortOrder",
+									"value": "asc"
+								}
+							]
+						}
+					},
+					"response": []
+				}
+			]
+		},
+		{
+			"name": "Published Theses",
+			"item": [
+				{
+					"name": "Specific Published Thesis",
+					"item": [
+						{
+							"name": "Get Published Thesis",
+							"request": {
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "{{baseUrl}}/published-theses/:thesisId/thesis",
+									"host": [
+										"{{baseUrl}}"
+									],
+									"path": [
+										"published-theses",
+										":thesisId",
+										"thesis"
+									],
+									"variable": [
+										{
+											"key": "thesisId",
+											"value": "d34084cc-0d98-4563-938c-17003c8a4935"
+										}
+									]
+								}
+							},
+							"response": []
+						}
+					]
+				},
+				{
+					"name": "Get All Published Theses",
+					"request": {
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "{{baseUrl}}/published-theses?page=0&limit=50&sortBy=endDate&sortOrder=asc",
+							"host": [
+								"{{baseUrl}}"
+							],
+							"path": [
+								"published-theses"
+							],
+							"query": [
+								{
+									"key": "page",
+									"value": "0"
+								},
+								{
+									"key": "limit",
+									"value": "50"
+								},
+								{
+									"key": "sortBy",
+									"value": "endDate"
+								},
+								{
+									"key": "sortOrder",
+									"value": "asc"
+								}
+							]
+						}
+					},
+					"response": []
+				}
+			]
+		},
+		{
+			"name": "Research Groups",
+			"item": [
+				{
+					"name": "Specific Research Group",
+					"item": [
+						{
+							"name": "Get Research Group",
+							"request": {
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "{{baseUrl}}/research-groups/:researchGroupId",
+									"host": [
+										"{{baseUrl}}"
+									],
+									"path": [
+										"research-groups",
+										":researchGroupId"
+									],
+									"variable": [
+										{
+											"key": "researchGroupId",
+											"value": "4d5c6f1b-6e83-4e5e-9f6a-2657dc724aec"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Update Research Group",
+							"request": {
+								"method": "PUT",
+								"header": [],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n    \"headId\": \"76638673-ca5e-4000-8f5c-3da377bf0eda\",\n    \"name\": \"Test\",\n    \"abbreviation\": \"Test\",\n    \"campus\": \"Test\",\n    \"description\": \"Test\",\n    \"websiteUrl\": \"Test\"\n}",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "{{baseUrl}}/research-groups/:researchGroupId",
+									"host": [
+										"{{baseUrl}}"
+									],
+									"path": [
+										"research-groups",
+										":researchGroupId"
+									],
+									"variable": [
+										{
+											"key": "researchGroupId",
+											"value": "b9111d31-7ccf-4d9b-869e-12d5e9ac4fc1"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Archive Research Group",
+							"request": {
+								"method": "PATCH",
+								"header": [],
+								"url": {
+									"raw": "{{baseUrl}}/research-groups/:id/archive",
+									"host": [
+										"{{baseUrl}}"
+									],
+									"path": [
+										"research-groups",
+										":id",
+										"archive"
+									],
+									"variable": [
+										{
+											"key": "id",
+											"value": "b9111d31-7ccf-4d9b-869e-12d5e9ac4fc1"
+										}
+									]
+								}
+							},
+							"response": []
+						}
+					]
+				},
+				{
+					"name": "Get All Research Groups",
+					"request": {
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "{{baseUrl}}/research-groups",
+							"host": [
+								"{{baseUrl}}"
+							],
+							"path": [
+								"research-groups"
+							],
+							"query": [
+								{
+									"key": "search",
+									"value": "Tes",
+									"disabled": true
+								},
+								{
+									"key": "heads",
+									"value": "fc139fff-f87d-4113-beab-7de4bc76babc",
+									"disabled": true
+								},
+								{
+									"key": "campuses",
+									"value": "Munich - Garching",
+									"disabled": true
+								},
+								{
+									"key": "includeArchived",
+									"value": "true",
+									"disabled": true
+								},
+								{
+									"key": "page",
+									"value": "0",
+									"disabled": true
+								},
+								{
+									"key": "limit",
+									"value": "50",
+									"disabled": true
+								},
+								{
+									"key": "sortBy",
+									"value": "name",
+									"disabled": true
+								},
+								{
+									"key": "sortOrder",
+									"value": "asc",
+									"disabled": true
+								}
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Add Research Group",
+					"request": {
+						"method": "POST",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"headId\": \"76638673-ca5e-4000-8f5c-3da377bf0eda\",\n    \"name\": \"Test\",\n    \"abbreviation\": \"Test\",\n    \"campus\": \"Test\",\n    \"description\": \"Test\",\n    \"websiteUrl\": \"Test\"\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{baseUrl}}/research-groups",
+							"host": [
+								"{{baseUrl}}"
+							],
+							"path": [
+								"research-groups"
+							]
+						}
+					},
+					"response": []
+				}
+			]
+		},
+		{
+			"name": "Tasks",
+			"item": [
+				{
+					"name": "Get All Tasks",
+					"request": {
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "{{baseUrl}}/dashboard/tasks",
+							"host": [
+								"{{baseUrl}}"
+							],
+							"path": [
+								"dashboard",
+								"tasks"
+							]
+						}
+					},
+					"response": []
+				}
+			]
+		},
+		{
+			"name": "Theses",
+			"item": [
+				{
+					"name": "Specific Thesis",
+					"item": [
+						{
+							"name": "Assessment",
+							"item": [
+								{
+									"name": "Get Assessment",
+									"request": {
+										"method": "GET",
+										"header": [
+											{
+												"key": "Content-Type",
+												"value": "application/json"
+											}
+										],
+										"url": {
+											"raw": "{{baseUrl}}/theses/:thesis_id/assessment",
+											"host": [
+												"{{baseUrl}}"
+											],
+											"path": [
+												"theses",
+												":thesis_id",
+												"assessment"
+											],
+											"variable": [
+												{
+													"key": "thesis_id",
+													"value": "d34084cc-0d98-4563-938c-17003c8a4935"
+												}
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "Add Assessment",
+									"request": {
+										"method": "POST",
+										"header": [
+											{
+												"key": "Content-Type",
+												"value": "application/json"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "{\n  \"summary\": \"summary\",\n  \"positives\": \"positives\",\n  \"negatives\": \"negatives\",\n  \"gradeSuggestion\": \"2.7\"\n}",
+											"options": {
+												"raw": {
+													"headerFamily": "json",
+													"language": "json"
+												}
+											}
+										},
+										"url": {
+											"raw": "{{baseUrl}}/theses/:thesis_id/assessment",
+											"host": [
+												"{{baseUrl}}"
+											],
+											"path": [
+												"theses",
+												":thesis_id",
+												"assessment"
+											],
+											"variable": [
+												{
+													"key": "thesis_id",
+													"value": "d34084cc-0d98-4563-938c-17003c8a4935",
+													"description": "(Required) "
+												}
+											]
+										}
+									},
+									"response": []
+								}
+							]
+						},
+						{
+							"name": "Comments",
+							"item": [
+								{
+									"name": "Get Comments",
+									"request": {
+										"method": "GET",
+										"header": [],
+										"url": {
+											"raw": "{{baseUrl}}/theses/:thesis_id/comments",
+											"host": [
+												"{{baseUrl}}"
+											],
+											"path": [
+												"theses",
+												":thesis_id",
+												"comments"
+											],
+											"variable": [
+												{
+													"key": "thesis_id",
+													"value": "180c941a-868d-4ea0-b294-543a30362e68",
+													"description": "(Required) "
+												}
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "Get Comment File",
+									"request": {
+										"method": "GET",
+										"header": [],
+										"url": {
+											"raw": "{{baseUrl}}/theses/:thesis_id/comments/:commentId/file",
+											"host": [
+												"{{baseUrl}}"
+											],
+											"path": [
+												"theses",
+												":thesis_id",
+												"comments",
+												":commentId",
+												"file"
+											],
+											"variable": [
+												{
+													"key": "thesis_id",
+													"value": "8e2e14ff-0231-4d37-9c26-f7d4f6e1392e"
+												},
+												{
+													"key": "commentId",
+													"value": "cfe9e1f2-74d9-45f6-9d6d-b16211e59cb9"
+												}
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "Add Comment",
+									"protocolProfileBehavior": {
+										"disabledSystemHeaders": {}
+									},
+									"request": {
+										"method": "POST",
+										"header": [
+											{
+												"key": "Content-Type",
+												"value": "application/json",
+												"disabled": true
+											}
+										],
+										"body": {
+											"mode": "formdata",
+											"formdata": [
+												{
+													"key": "data",
+													"value": "{\"message\": \"test message\", \"commentType\": \"ADVISOR\"}",
+													"type": "text"
+												},
+												{
+													"key": "file",
+													"type": "file",
+													"src": "/Users/marcfett/Downloads/Test PDF.pdf"
+												}
+											]
+										},
+										"url": {
+											"raw": "{{baseUrl}}/theses/:thesis_id/comments",
+											"host": [
+												"{{baseUrl}}"
+											],
+											"path": [
+												"theses",
+												":thesis_id",
+												"comments"
+											],
+											"variable": [
+												{
+													"key": "thesis_id",
+													"value": "180c941a-868d-4ea0-b294-543a30362e68",
+													"description": "(Required) "
+												}
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "Delete Comment",
+									"protocolProfileBehavior": {
+										"disabledSystemHeaders": {}
+									},
+									"request": {
+										"method": "DELETE",
+										"header": [
+											{
+												"key": "Content-Type",
+												"value": "application/json",
+												"disabled": true
+											}
+										],
+										"url": {
+											"raw": "{{baseUrl}}/theses/:thesis_id/comments/:commentId",
+											"host": [
+												"{{baseUrl}}"
+											],
+											"path": [
+												"theses",
+												":thesis_id",
+												"comments",
+												":commentId"
+											],
+											"variable": [
+												{
+													"key": "thesis_id",
+													"value": "d34084cc-0d98-4563-938c-17003c8a4935",
+													"description": "(Required) "
+												},
+												{
+													"key": "commentId",
+													"value": "11ae7ce5-9251-4f7b-82a0-e20eac706f2c"
+												}
+											]
+										}
+									},
+									"response": []
+								}
+							]
+						},
+						{
+							"name": "Credits",
+							"item": [
+								{
+									"name": "Update Credits",
+									"request": {
+										"method": "PUT",
+										"header": [],
+										"body": {
+											"mode": "raw",
+											"raw": "{\n    \"credits\": {\n        \"fdde346c-4ad0-4e5a-82b8-93191553e325\": 15\n    }\n}",
+											"options": {
+												"raw": {
+													"language": "json"
+												}
+											}
+										},
+										"url": {
+											"raw": "{{baseUrl}}/theses/:thesis_id/credits",
+											"host": [
+												"{{baseUrl}}"
+											],
+											"path": [
+												"theses",
+												":thesis_id",
+												"credits"
+											],
+											"variable": [
+												{
+													"key": "thesis_id",
+													"value": "acabc92a-d4ac-4bb4-9d35-02703ed39ac1"
+												}
+											]
+										}
+									},
+									"response": []
+								}
+							]
+						},
+						{
+							"name": "Feedback",
+							"item": [
+								{
+									"name": "Add Feedback",
+									"request": {
+										"method": "POST",
+										"header": [],
+										"body": {
+											"mode": "raw",
+											"raw": "{\n    \"type\": \"PROPOSAL\",\n    \"requestedChanges\": [\n        {\n            \"feedback\": \"feedback\",\n            \"completed\": false\n        }\n    ]\n}",
+											"options": {
+												"raw": {
+													"language": "json"
+												}
+											}
+										},
+										"url": {
+											"raw": "{{baseUrl}}/theses/:thesis_id/feedback",
+											"host": [
+												"{{baseUrl}}"
+											],
+											"path": [
+												"theses",
+												":thesis_id",
+												"feedback"
+											],
+											"variable": [
+												{
+													"key": "thesis_id",
+													"value": "acabc92a-d4ac-4bb4-9d35-02703ed39ac1"
+												}
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "Complete Feedback",
+									"request": {
+										"method": "PUT",
+										"header": [],
+										"body": {
+											"mode": "raw",
+											"raw": "{\n    \"type\": \"PROPOSAL\",\n    \"requestedChanges\": [\n        {\n            \"feedback\": \"feedback\",\n            \"completed\": false\n        }\n    ]\n}",
+											"options": {
+												"raw": {
+													"language": "json"
+												}
+											}
+										},
+										"url": {
+											"raw": "{{baseUrl}}/theses/:thesis_id/feedback/:feedbackId/:action",
+											"host": [
+												"{{baseUrl}}"
+											],
+											"path": [
+												"theses",
+												":thesis_id",
+												"feedback",
+												":feedbackId",
+												":action"
+											],
+											"variable": [
+												{
+													"key": "thesis_id",
+													"value": "acabc92a-d4ac-4bb4-9d35-02703ed39ac1"
+												},
+												{
+													"key": "feedbackId",
+													"value": "872ceb19-1bb2-4ead-a098-abf387d47ba1"
+												},
+												{
+													"key": "action",
+													"value": "complete"
+												}
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "Delete Feedback",
+									"request": {
+										"method": "DELETE",
+										"header": [],
+										"url": {
+											"raw": "{{baseUrl}}/theses/:thesis_id/feedback/:feedbackId",
+											"host": [
+												"{{baseUrl}}"
+											],
+											"path": [
+												"theses",
+												":thesis_id",
+												"feedback",
+												":feedbackId"
+											],
+											"variable": [
+												{
+													"key": "thesis_id",
+													"value": "986a60ee-a856-44b1-af5b-01c039461045"
+												},
+												{
+													"key": "feedbackId",
+													"value": "fcf897a4-b2cb-431a-b424-10aa952e2c40"
+												}
+											]
+										}
+									},
+									"response": []
+								}
+							]
+						},
+						{
+							"name": "Files",
+							"item": [
+								{
+									"name": "Get File",
+									"protocolProfileBehavior": {
+										"disableBodyPruning": true
+									},
+									"request": {
+										"method": "GET",
+										"header": [],
+										"body": {
+											"mode": "formdata",
+											"formdata": [
+												{
+													"key": "type",
+													"value": "THESIS",
+													"type": "text"
+												},
+												{
+													"key": "file",
+													"type": "file",
+													"src": []
+												}
+											]
+										},
+										"url": {
+											"raw": "{{baseUrl}}/theses/:thesis_id/files/:fileId",
+											"host": [
+												"{{baseUrl}}"
+											],
+											"path": [
+												"theses",
+												":thesis_id",
+												"files",
+												":fileId"
+											],
+											"variable": [
+												{
+													"key": "thesis_id",
+													"value": "180c941a-868d-4ea0-b294-543a30362e68"
+												},
+												{
+													"key": "fileId",
+													"value": "f52c83c0-ba9d-46be-801e-4e1436dc4e10"
+												}
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "Add File",
+									"request": {
+										"method": "POST",
+										"header": [],
+										"body": {
+											"mode": "formdata",
+											"formdata": [
+												{
+													"key": "type",
+													"value": "THESIS",
+													"type": "text"
+												},
+												{
+													"key": "file",
+													"type": "file",
+													"src": []
+												}
+											]
+										},
+										"url": {
+											"raw": "{{baseUrl}}/theses/:thesis_id/files",
+											"host": [
+												"{{baseUrl}}"
+											],
+											"path": [
+												"theses",
+												":thesis_id",
+												"files"
+											],
+											"variable": [
+												{
+													"key": "thesis_id",
+													"value": "180c941a-868d-4ea0-b294-543a30362e68"
+												}
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "Delete File",
+									"request": {
+										"method": "DELETE",
+										"header": [],
+										"body": {
+											"mode": "formdata",
+											"formdata": [
+												{
+													"key": "type",
+													"value": "THESIS",
+													"type": "text"
+												},
+												{
+													"key": "file",
+													"type": "file",
+													"src": []
+												}
+											]
+										},
+										"url": {
+											"raw": "{{baseUrl}}/theses/:thesis_id/files/:fileId",
+											"host": [
+												"{{baseUrl}}"
+											],
+											"path": [
+												"theses",
+												":thesis_id",
+												"files",
+												":fileId"
+											],
+											"variable": [
+												{
+													"key": "thesis_id",
+													"value": "180c941a-868d-4ea0-b294-543a30362e68"
+												},
+												{
+													"key": "fileId",
+													"value": "f52c83c0-ba9d-46be-801e-4e1436dc4e10"
+												}
+											]
+										}
+									},
+									"response": []
+								}
+							]
+						},
+						{
+							"name": "Grade",
+							"item": [
+								{
+									"name": "Update Credits",
+									"request": {
+										"method": "POST",
+										"header": [],
+										"body": {
+											"mode": "raw",
+											"raw": "{\n    \"finalGrade\": \"2.7\",\n    \"finalFeedback\": \"finalFeedback\",\n    \"visibility\": \"PUBLIC\"\n}",
+											"options": {
+												"raw": {
+													"language": "json"
+												}
+											}
+										},
+										"url": {
+											"raw": "{{baseUrl}}/theses/:thesis_id/grade",
+											"host": [
+												"{{baseUrl}}"
+											],
+											"path": [
+												"theses",
+												":thesis_id",
+												"grade"
+											],
+											"variable": [
+												{
+													"key": "thesis_id",
+													"value": "acabc92a-d4ac-4bb4-9d35-02703ed39ac1"
+												}
+											]
+										}
+									},
+									"response": []
+								}
+							]
+						},
+						{
+							"name": "Info",
+							"item": [
+								{
+									"name": "Update Thesis Info",
+									"request": {
+										"method": "PUT",
+										"header": [],
+										"body": {
+											"mode": "raw",
+											"raw": "{\n    \"abstractText\": \"abstractText\",\n    \"infoText\": \"infoText\",\n    \"primaryTitle\": \"primaryTitle\",\n    \"secondaryTitles\": {\n        \"test\": \"test\"\n    }\n}",
+											"options": {
+												"raw": {
+													"language": "json"
+												}
+											}
+										},
+										"url": {
+											"raw": "{{baseUrl}}/theses/:thesis_id/info",
+											"host": [
+												"{{baseUrl}}"
+											],
+											"path": [
+												"theses",
+												":thesis_id",
+												"info"
+											],
+											"variable": [
+												{
+													"key": "thesis_id",
+													"value": "acabc92a-d4ac-4bb4-9d35-02703ed39ac1"
+												}
+											]
+										}
+									},
+									"response": []
+								}
+							]
+						},
+						{
+							"name": "Presentations",
+							"item": [
+								{
+									"name": "Specific Presentation",
+									"item": [
+										{
+											"name": "Update Presentation",
+											"request": {
+												"method": "PUT",
+												"header": [],
+												"body": {
+													"mode": "raw",
+													"raw": "{\n    \"type\": \"INTERMEDIATE\",\n    \"visibility\": \"PUBLIC\",\n    \"location\": \"TUM\",\n    \"streamUrl\": \"https://www.google.de\",\n    \"language\": \"ENGLISH\",\n    \"date\": {{$timestamp}}\n}",
+													"options": {
+														"raw": {
+															"language": "json"
+														}
+													}
+												},
+												"url": {
+													"raw": "{{baseUrl}}/theses/:thesis_id/presentations/:presentationId",
+													"host": [
+														"{{baseUrl}}"
+													],
+													"path": [
+														"theses",
+														":thesis_id",
+														"presentations",
+														":presentationId"
+													],
+													"variable": [
+														{
+															"key": "thesis_id",
+															"value": "180c941a-868d-4ea0-b294-543a30362e68"
+														},
+														{
+															"key": "presentationId",
+															"value": "d0b63a29-cc30-437a-8c8f-0796e91eeff6"
+														}
+													]
+												}
+											},
+											"response": []
+										},
+										{
+											"name": "Schedule Presentation",
+											"request": {
+												"method": "POST",
+												"header": [],
+												"body": {
+													"mode": "raw",
+													"raw": "{\n    \"optionalAttendees\": [],\n    \"inviteChairMember\": true,\n    \"inviteThesisStudents\": true\n}",
+													"options": {
+														"raw": {
+															"language": "json"
+														}
+													}
+												},
+												"url": {
+													"raw": "{{baseUrl}}/theses/:thesis_id/presentations/:presentationId/schedule",
+													"host": [
+														"{{baseUrl}}"
+													],
+													"path": [
+														"theses",
+														":thesis_id",
+														"presentations",
+														":presentationId",
+														"schedule"
+													],
+													"variable": [
+														{
+															"key": "thesis_id",
+															"value": "180c941a-868d-4ea0-b294-543a30362e68"
+														},
+														{
+															"key": "presentationId",
+															"value": "d0b63a29-cc30-437a-8c8f-0796e91eeff6"
+														}
+													]
+												}
+											},
+											"response": []
+										},
+										{
+											"name": "Delete Presentation",
+											"request": {
+												"method": "DELETE",
+												"header": [],
+												"url": {
+													"raw": "{{baseUrl}}/theses/:thesis_id/presentations/:presentationId",
+													"host": [
+														"{{baseUrl}}"
+													],
+													"path": [
+														"theses",
+														":thesis_id",
+														"presentations",
+														":presentationId"
+													],
+													"variable": [
+														{
+															"key": "thesis_id",
+															"value": "180c941a-868d-4ea0-b294-543a30362e68"
+														},
+														{
+															"key": "presentationId",
+															"value": "d0b63a29-cc30-437a-8c8f-0796e91eeff6"
+														}
+													]
+												}
+											},
+											"response": []
+										}
+									]
+								},
+								{
+									"name": "Add Presentation",
+									"request": {
+										"method": "POST",
+										"header": [],
+										"body": {
+											"mode": "raw",
+											"raw": "{\n    \"type\": \"INTERMEDIATE\",\n    \"visibility\": \"PUBLIC\",\n    \"location\": \"TUM\",\n    \"streamUrl\": \"https://www.google.de\",\n    \"language\": \"ENGLISH\",\n    \"date\": {{$timestamp}}\n}",
+											"options": {
+												"raw": {
+													"language": "json"
+												}
+											}
+										},
+										"url": {
+											"raw": "{{baseUrl}}/theses/:thesis_id/presentations",
+											"host": [
+												"{{baseUrl}}"
+											],
+											"path": [
+												"theses",
+												":thesis_id",
+												"presentations"
+											],
+											"variable": [
+												{
+													"key": "thesis_id",
+													"value": "8e2e14ff-0231-4d37-9c26-f7d4f6e1392e"
+												}
+											]
+										}
+									},
+									"response": []
+								}
+							]
+						},
+						{
+							"name": "Proposal",
+							"item": [
+								{
+									"name": "Specific Proposal",
+									"item": [
+										{
+											"name": "Get Proposal",
+											"request": {
+												"method": "GET",
+												"header": [],
+												"url": {
+													"raw": "{{baseUrl}}/theses/:thesis_id/proposal/:proposalId",
+													"host": [
+														"{{baseUrl}}"
+													],
+													"path": [
+														"theses",
+														":thesis_id",
+														"proposal",
+														":proposalId"
+													],
+													"variable": [
+														{
+															"key": "thesis_id",
+															"value": "8e2e14ff-0231-4d37-9c26-f7d4f6e1392e"
+														},
+														{
+															"key": "proposalId",
+															"value": "a152a2a2-6d72-4a0a-bea3-3bd82b43bb04"
+														}
+													]
+												}
+											},
+											"response": []
+										},
+										{
+											"name": "Delete Proposal",
+											"request": {
+												"method": "DELETE",
+												"header": [],
+												"url": {
+													"raw": "{{baseUrl}}/theses/:thesis_id/proposal/:proposalId",
+													"host": [
+														"{{baseUrl}}"
+													],
+													"path": [
+														"theses",
+														":thesis_id",
+														"proposal",
+														":proposalId"
+													],
+													"variable": [
+														{
+															"key": "thesis_id",
+															"value": "8e2e14ff-0231-4d37-9c26-f7d4f6e1392e"
+														},
+														{
+															"key": "proposalId",
+															"value": "a152a2a2-6d72-4a0a-bea3-3bd82b43bb04"
+														}
+													]
+												}
+											},
+											"response": []
+										}
+									]
+								},
+								{
+									"name": "Add Proposal",
+									"request": {
+										"method": "POST",
+										"header": [],
+										"body": {
+											"mode": "formdata",
+											"formdata": [
+												{
+													"key": "proposalFile",
+													"type": "file",
+													"src": []
+												}
+											]
+										},
+										"url": {
+											"raw": "{{baseUrl}}/theses/:thesis_id/proposal",
+											"host": [
+												"{{baseUrl}}"
+											],
+											"path": [
+												"theses",
+												":thesis_id",
+												"proposal"
+											],
+											"variable": [
+												{
+													"key": "thesis_id",
+													"value": "acabc92a-d4ac-4bb4-9d35-02703ed39ac1"
+												}
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "Accept Proposal",
+									"request": {
+										"method": "PUT",
+										"header": [],
+										"url": {
+											"raw": "{{baseUrl}}/theses/:thesis_id/proposal/accept",
+											"host": [
+												"{{baseUrl}}"
+											],
+											"path": [
+												"theses",
+												":thesis_id",
+												"proposal",
+												"accept"
+											],
+											"variable": [
+												{
+													"key": "thesis_id",
+													"value": "acabc92a-d4ac-4bb4-9d35-02703ed39ac1"
+												}
+											]
+										}
+									},
+									"response": []
+								}
+							]
+						},
+						{
+							"name": "Get Thesis",
+							"request": {
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "{{baseUrl}}/theses/:thesis_id",
+									"host": [
+										"{{baseUrl}}"
+									],
+									"path": [
+										"theses",
+										":thesis_id"
+									],
+									"variable": [
+										{
+											"key": "thesis_id",
+											"value": "acabc92a-d4ac-4bb4-9d35-02703ed39ac1"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Update Thesis",
+							"request": {
+								"method": "PUT",
+								"header": [
+									{
+										"key": "Content-Type",
+										"value": "application/json"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n    \"thesisTitle\": \"Test\",\n    \"thesisType\": \"BACHELOR\",\n    \"language\": \"ENGLISCH\",\n    \"visibility\": \"PUBLIC\",\n    \"keywords\": [\n        \"test\"\n    ],\n    \"startDate\": {{$timestamp}},\n    \"endDate\": {{$timestamp}},\n    \"studentIds\": [\n        \"7d015f04-2ee0-4a84-8427-bb5d60380651\"\n    ],\n    \"advisorIds\": [\n        \"76638673-ca5e-4000-8f5c-3da377bf0eda\"\n    ],\n    \"supervisorIds\": [\n        \"76638673-ca5e-4000-8f5c-3da377bf0eda\"\n    ],\n    \"states\": [\n        {\n            \"state\": \"PROPOSAL\",\n            \"changedAt\": {{$timestamp}}\n        }\n    ]\n}",
+									"options": {
+										"raw": {
+											"headerFamily": "json",
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "{{baseUrl}}/theses/:thesis_id",
+									"host": [
+										"{{baseUrl}}"
+									],
+									"path": [
+										"theses",
+										":thesis_id"
+									],
+									"variable": [
+										{
+											"key": "thesis_id",
+											"value": "acabc92a-d4ac-4bb4-9d35-02703ed39ac1",
+											"description": "(Required) "
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Submit Thesis",
+							"request": {
+								"method": "PUT",
+								"header": [],
+								"url": {
+									"raw": "{{baseUrl}}/theses/:thesis_id/thesis/final-submission",
+									"host": [
+										"{{baseUrl}}"
+									],
+									"path": [
+										"theses",
+										":thesis_id",
+										"thesis",
+										"final-submission"
+									],
+									"variable": [
+										{
+											"key": "thesis_id",
+											"value": "acabc92a-d4ac-4bb4-9d35-02703ed39ac1"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Complete Thesis",
+							"request": {
+								"method": "POST",
+								"header": [
+									{
+										"key": "Content-Type",
+										"value": "application/json"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n    \"thesisTitle\": \"Test\",\n    \"thesisType\": \"BACHELOR\",\n    \"language\": \"ENGLISCH\",\n    \"visibility\": \"PUBLIC\",\n    \"keywords\": [\n        \"test\"\n    ],\n    \"startDate\": {{$timestamp}},\n    \"endDate\": {{$timestamp}},\n    \"studentIds\": [\n        \"7d015f04-2ee0-4a84-8427-bb5d60380651\"\n    ],\n    \"advisorIds\": [\n        \"76638673-ca5e-4000-8f5c-3da377bf0eda\"\n    ],\n    \"supervisorIds\": [\n        \"76638673-ca5e-4000-8f5c-3da377bf0eda\"\n    ],\n    \"states\": [\n        {\n            \"state\": \"PROPOSAL\",\n            \"changedAt\": {{$timestamp}}\n        }\n    ]\n}",
+									"options": {
+										"raw": {
+											"headerFamily": "json",
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "{{baseUrl}}/theses/:thesis_id/complete",
+									"host": [
+										"{{baseUrl}}"
+									],
+									"path": [
+										"theses",
+										":thesis_id",
+										"complete"
+									],
+									"variable": [
+										{
+											"key": "thesis_id",
+											"value": "acabc92a-d4ac-4bb4-9d35-02703ed39ac1",
+											"description": "(Required) "
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Close Thesis",
+							"request": {
+								"method": "DELETE",
+								"header": [],
+								"url": {
+									"raw": "{{baseUrl}}/theses/:thesis_id",
+									"host": [
+										"{{baseUrl}}"
+									],
+									"path": [
+										"theses",
+										":thesis_id"
+									],
+									"variable": [
+										{
+											"key": "thesis_id",
+											"value": "acabc92a-d4ac-4bb4-9d35-02703ed39ac1",
+											"description": "(Required) "
+										}
+									]
+								}
+							},
+							"response": []
+						}
+					]
+				},
+				{
+					"name": "Get All Theses",
+					"request": {
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "{{baseUrl}}/theses",
+							"host": [
+								"{{baseUrl}}"
+							],
+							"path": [
+								"theses"
+							],
+							"query": [
+								{
+									"key": "search",
+									"value": "123",
+									"disabled": true
+								},
+								{
+									"key": "state",
+									"value": "WRITING",
+									"disabled": true
+								},
+								{
+									"key": "type",
+									"value": "BACHELOR",
+									"disabled": true
+								},
+								{
+									"key": "fetchAll",
+									"value": "true",
+									"disabled": true
+								},
+								{
+									"key": "page",
+									"value": "0",
+									"disabled": true
+								},
+								{
+									"key": "limit",
+									"value": "50",
+									"disabled": true
+								},
+								{
+									"key": "sortBy",
+									"value": "createdAt",
+									"disabled": true
+								},
+								{
+									"key": "sortOrder",
+									"value": "asc",
+									"disabled": true
+								},
+								{
+									"key": "onlyOwnResearchGroup",
+									"value": "false",
+									"disabled": true
+								}
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Create Thesis",
+					"request": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "Content-Type",
+								"value": "application/json"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"thesisTitle\": \"Test\",\n    \"thesisType\": \"BACHELOR\",\n    \"language\": \"ENGLISCH\",\n    \"studentIds\": [\n        \"7d015f04-2ee0-4a84-8427-bb5d60380651\"\n    ],\n    \"advisorIds\": [\n        \"76638673-ca5e-4000-8f5c-3da377bf0eda\"\n    ],\n    \"supervisorIds\": [\n        \"76638673-ca5e-4000-8f5c-3da377bf0eda\"\n    ]\n}",
+							"options": {
+								"raw": {
+									"headerFamily": "json",
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{baseUrl}}/theses",
+							"host": [
+								"{{baseUrl}}"
+							],
+							"path": [
+								"theses"
+							]
+						}
+					},
+					"response": []
+				}
+			]
+		},
+		{
+			"name": "Topics",
+			"item": [
+				{
+					"name": "Specific Topic",
+					"item": [
+						{
+							"name": "Get Topic",
+							"request": {
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "{{baseUrl}}/topics/:topic_id",
+									"host": [
+										"{{baseUrl}}"
+									],
+									"path": [
+										"topics",
+										":topic_id"
+									],
+									"variable": [
+										{
+											"key": "topic_id",
+											"value": "54696a2c-b4f6-432e-a5c8-1d8f190c35bc",
+											"description": "(Required) "
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Update Topic",
+							"request": {
+								"method": "PUT",
+								"header": [
+									{
+										"key": "Content-Type",
+										"value": "application/json"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n  \"title\": \"title\",\n  \"thesisTypes\": [\"BACHELOR\"],\n  \"problemStatement\": \"prolbem statement\",\n  \"requirements\": \"requirements\",\n  \"goals\": \"goals\",\n  \"references\": \"references\",\n  \"supervisorIds\": [\"fdde346c-4ad0-4e5a-82b8-93191553e325\"],\n  \"advisorIds\": [\"fdde346c-4ad0-4e5a-82b8-93191553e325\"]\n}",
+									"options": {
+										"raw": {
+											"headerFamily": "json",
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "{{baseUrl}}/topics/:topic_id",
+									"host": [
+										"{{baseUrl}}"
+									],
+									"path": [
+										"topics",
+										":topic_id"
+									],
+									"variable": [
+										{
+											"key": "topic_id",
+											"value": "54696a2c-b4f6-432e-a5c8-1d8f190c35bc",
+											"description": "(Required) "
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Delete Topic",
+							"request": {
+								"method": "DELETE",
+								"header": [],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n    \"reason\": \"TOPIC_FILLED\",\n    \"notifyUser\": true\n}",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "{{baseUrl}}/topics/:topic_id",
+									"host": [
+										"{{baseUrl}}"
+									],
+									"path": [
+										"topics",
+										":topic_id"
+									],
+									"variable": [
+										{
+											"key": "topic_id",
+											"value": "54696a2c-b4f6-432e-a5c8-1d8f190c35bc",
+											"description": "(Required) "
+										}
+									]
+								}
+							},
+							"response": []
+						}
+					]
+				},
+				{
+					"name": "Get All Topics",
+					"request": {
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "{{baseUrl}}/topics",
+							"host": [
+								"{{baseUrl}}"
+							],
+							"path": [
+								"topics"
+							],
+							"query": [
+								{
+									"key": "search",
+									"value": "T",
+									"disabled": true
+								},
+								{
+									"key": "type",
+									"value": "BACHELOR",
+									"disabled": true
+								},
+								{
+									"key": "includedClosed",
+									"value": "true",
+									"disabled": true
+								},
+								{
+									"key": "page",
+									"value": "0",
+									"disabled": true
+								},
+								{
+									"key": "limit",
+									"value": "50",
+									"disabled": true
+								},
+								{
+									"key": "sortBy",
+									"value": "createdAt",
+									"disabled": true
+								},
+								{
+									"key": "sortOrder",
+									"value": "asc",
+									"disabled": true
+								},
+								{
+									"key": "onlyOwnResearchGroup",
+									"value": "false",
+									"disabled": true
+								}
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Create Topic",
+					"request": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "Content-Type",
+								"value": "application/json"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n  \"title\": \"title\",\n  \"thesisTypes\": [\"BACHELOR\"],\n  \"problemStatement\": \"prolbem statement\",\n  \"requirements\": \"requirements\",\n  \"goals\": \"goals\",\n  \"references\": \"references\",\n  \"supervisorIds\": [\"fdde346c-4ad0-4e5a-82b8-93191553e325\"],\n  \"advisorIds\": [\"fdde346c-4ad0-4e5a-82b8-93191553e325\"]\n}",
+							"options": {
+								"raw": {
+									"headerFamily": "json",
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{baseUrl}}/topics",
+							"host": [
+								"{{baseUrl}}"
+							],
+							"path": [
+								"topics"
+							]
+						}
+					},
+					"response": []
+				}
+			]
+		},
+		{
+			"name": "User Information",
+			"item": [
+				{
+					"name": "Notifications",
+					"item": [
+						{
+							"name": "Get Notification Settings",
+							"request": {
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "{{baseUrl}}/user-info/notifications",
+									"host": [
+										"{{baseUrl}}"
+									],
+									"path": [
+										"user-info",
+										"notifications"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Update Notification Settings",
+							"request": {
+								"method": "PUT",
+								"header": [],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n    \"name\": \"Test\",\n    \"email\": \"test@test.de\"\n}",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "{{baseUrl}}/user-info/notifications",
+									"host": [
+										"{{baseUrl}}"
+									],
+									"path": [
+										"user-info",
+										"notifications"
+									]
+								}
+							},
+							"response": []
+						}
+					]
+				},
+				{
+					"name": "Get Current User",
+					"request": {
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "{{baseUrl}}/user-info",
+							"host": [
+								"{{baseUrl}}"
+							],
+							"path": [
+								"user-info"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Update Current User",
+					"protocolProfileBehavior": {
+						"disabledSystemHeaders": {}
+					},
+					"request": {
+						"method": "PUT",
+						"header": [],
+						"body": {
+							"mode": "formdata",
+							"formdata": [
+								{
+									"key": "data",
+									"value": "{\n\"matriculationNumber\": \"123456\",\n\"firstName\": \"Max\",\n\"lastName\": \"Mustermann\",\n\"gender\": \"male\",\n\"nationality\": \"German\",\n\"email\": \"max.mustermann@example.com\",\n\"studyDegree\": \"Bachelor\",\n\"studyProgram\": \"Informatik\",\n\"enrolledAt\": \"2023-01-01T00:00:00Z\",\n\"specialSkills\": \"Java, Spring Boot\",\n\"interests\": \"AI, Machine Learning\",\n\"projects\": \"Thesis Project\",\n\"customData\": {\n    \"key1\": \"value1\",\n    \"key2\": \"value2\"\n}\n}",
+									"type": "text"
+								},
+								{
+									"key": "examinationReport",
+									"type": "file",
+									"src": [],
+									"disabled": true
+								},
+								{
+									"key": "cv",
+									"type": "file",
+									"src": [],
+									"disabled": true
+								},
+								{
+									"key": "degreeReport",
+									"type": "file",
+									"src": [],
+									"disabled": true
+								},
+								{
+									"key": "avatar",
+									"type": "file",
+									"src": [],
+									"disabled": true
+								}
+							]
+						},
+						"url": {
+							"raw": "{{baseUrl}}/user-info",
+							"host": [
+								"{{baseUrl}}"
+							],
+							"path": [
+								"user-info"
+							]
+						}
+					},
+					"response": []
+				}
+			]
+		},
+		{
+			"name": "Users",
+			"item": [
+				{
+					"name": "Specific User",
+					"item": [
+						{
+							"name": "Get CV",
+							"request": {
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "{{baseUrl}}/users/:userId/cv",
+									"host": [
+										"{{baseUrl}}"
+									],
+									"path": [
+										"users",
+										":userId",
+										"cv"
+									],
+									"variable": [
+										{
+											"key": "userId",
+											"value": "7d015f04-2ee0-4a84-8427-bb5d60380651"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Get Degree Report",
+							"request": {
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "{{baseUrl}}/users/:userId/degree-report",
+									"host": [
+										"{{baseUrl}}"
+									],
+									"path": [
+										"users",
+										":userId",
+										"degree-report"
+									],
+									"variable": [
+										{
+											"key": "userId",
+											"value": "7d015f04-2ee0-4a84-8427-bb5d60380651"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Get Examination Report",
+							"request": {
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "{{baseUrl}}/users/:userId/examination-report",
+									"host": [
+										"{{baseUrl}}"
+									],
+									"path": [
+										"users",
+										":userId",
+										"examination-report"
+									],
+									"variable": [
+										{
+											"key": "userId",
+											"value": "7d015f04-2ee0-4a84-8427-bb5d60380651"
+										}
+									]
+								}
+							},
+							"response": []
+						}
+					]
+				},
+				{
+					"name": "Get All Users",
+					"request": {
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "{{baseUrl}}/users?searchQuery=F&groups=student&page=0&limit=50&sortBy=joinedAt&sortOrder=asc",
+							"host": [
+								"{{baseUrl}}"
+							],
+							"path": [
+								"users"
+							],
+							"query": [
+								{
+									"key": "searchQuery",
+									"value": "F"
+								},
+								{
+									"key": "groups",
+									"value": "student"
+								},
+								{
+									"key": "page",
+									"value": "0"
+								},
+								{
+									"key": "limit",
+									"value": "50"
+								},
+								{
+									"key": "sortBy",
+									"value": "joinedAt"
+								},
+								{
+									"key": "sortOrder",
+									"value": "asc"
+								}
+							]
+						}
+					},
+					"response": []
+				}
+			]
+		}
+	],
+	"auth": {
+		"type": "oauth2",
+		"oauth2": [
+			{
+				"key": "refreshTokenUrl",
+				"value": "{{baseKeycloakUrl}}/realms/{{realm}}/protocol/openid-connect/token",
+				"type": "string"
+			},
+			{
+				"key": "state",
+				"value": "{{$guid}}",
+				"type": "string"
+			},
+			{
+				"key": "scope",
+				"value": "openid",
+				"type": "string"
+			},
+			{
+				"key": "clientId",
+				"value": "{{clientId}}",
+				"type": "string"
+			},
+			{
+				"key": "accessTokenUrl",
+				"value": "{{baseKeycloakUrl}}/realms/{{realm}}/protocol/openid-connect/token",
+				"type": "string"
+			},
+			{
+				"key": "authUrl",
+				"value": "{{baseKeycloakUrl}}/realms/{{realm}}/protocol/openid-connect/auth",
+				"type": "string"
+			},
+			{
+				"key": "redirect_uri",
+				"value": "{{redirectUrl}}",
+				"type": "string"
+			},
+			{
+				"key": "grant_type",
+				"value": "authorization_code_with_pkce",
+				"type": "string"
+			},
+			{
+				"key": "tokenName",
+				"value": "Keycloak Token",
+				"type": "string"
+			},
+			{
+				"key": "addTokenTo",
+				"value": "header",
+				"type": "string"
+			}
+		]
+	},
+	"event": [
+		{
+			"listen": "prerequest",
+			"script": {
+				"type": "text/javascript",
+				"packages": {},
+				"exec": [
+					"const currentTime = Math.floor(Date.now() / 1000);",
+					"const accessTokenExp = parseInt(pm.environment.get(\"access_token_exp\") || \"0\");",
+					"",
+					"if (currentTime >= accessTokenExp) {",
+					"    console.log(\"Access token expired or not present. Requesting new token...\");",
+					"",
+					"    const server = pm.environment.get(\"server\");",
+					"    const realm = pm.environment.get(\"realm\");",
+					"    const clientId = pm.environment.get(\"client_id\");",
+					"    const username = pm.environment.get(\"username\");",
+					"    const password = pm.environment.get(\"password\");",
+					"",
+					"    const tokenUrl = `${server}/realms/${realm}/protocol/openid-connect/token`;",
+					"",
+					"    const formBody = `client_id=${encodeURIComponent(clientId)}&grant_type=password&username=${encodeURIComponent(username)}&password=${encodeURIComponent(password)}`;",
+					"",
+					"    pm.sendRequest({",
+					"        url: tokenUrl,",
+					"        method: 'POST',",
+					"        header: {",
+					"            'Content-Type': 'application/x-www-form-urlencoded'",
+					"        },",
+					"        body: {",
+					"            mode: 'raw',",
+					"            raw: formBody",
+					"        }",
+					"    }, function (err, res) {",
+					"        if (err || res.code !== 200) {",
+					"            console.error(\"Token refresh failed\", err || res.status);",
+					"        } else {",
+					"            const json = res.json();",
+					"",
+					"            pm.environment.set(\"access_token\", json.access_token);",
+					"            pm.environment.set(\"refresh_token\", json.refresh_token); // Falls erneuert wurde",
+					"",
+					"            const expiresIn = json.expires_in || 300;",
+					"            const newExp = Math.floor(Date.now() / 1000) + expiresIn;",
+					"            pm.environment.set(\"access_token_exp\", newExp.toString());",
+					"",
+					"            console.log(\"Access token refreshed\");",
+					"        }",
+					"    });",
+					"} else {",
+					"    console.log(\"Access token is still valid.\");",
+					"}"
+				]
+			}
+		},
+		{
+			"listen": "test",
+			"script": {
+				"type": "text/javascript",
+				"packages": {},
+				"exec": [
+					""
+				]
+			}
+		}
+	],
+	"variable": [
+		{
+			"key": "baseUrl",
+			"value": "http://localhost:8080/api/vs"
+		},
+		{
+			"key": "baseKeycloakUrl",
+			"value": "http://localhost:8081",
+			"type": "string"
+		},
+		{
+			"key": "redirectUrl",
+			"value": "http://localhost:3000/dashboard",
+			"type": "string"
+		},
+		{
+			"key": "realm",
+			"value": "thesis-management",
+			"type": "string"
+		},
+		{
+			"key": "clientId",
+			"value": "thesis-management-app",
+			"type": "string"
+		},
+		{
+			"key": "username",
+			"value": "",
+			"type": "string"
+		},
+		{
+			"key": "password",
+			"value": "",
+			"type": "string"
+		},
+		{
+			"key": "refreshToken",
+			"value": "",
+			"type": "string"
+		}
+	]
+}

--- a/docs/Thesis Management API.postman_collection.json
+++ b/docs/Thesis Management API.postman_collection.json
@@ -717,6 +717,36 @@
 								}
 							},
 							"response": []
+						},
+						{
+							"name": "Assign User to Research Group",
+							"request": {
+								"method": "PUT",
+								"header": [],
+								"url": {
+									"raw": "{{baseUrl}}/research-groups/:researchGroupId/assign/:userId",
+									"host": [
+										"{{baseUrl}}"
+									],
+									"path": [
+										"research-groups",
+										":researchGroupId",
+										"assign",
+										":userId"
+									],
+									"variable": [
+										{
+											"key": "researchGroupId",
+											"value": "df062fe9-1072-4fe4-af01-858d315af30d"
+										},
+										{
+											"key": "userId",
+											"value": "b8d13e55-0b27-4b58-9b57-ca3c726f8a70"
+										}
+									]
+								}
+							},
+							"response": []
 						}
 					]
 				},

--- a/server/build.gradle
+++ b/server/build.gradle
@@ -120,7 +120,8 @@ test {
 }
 
 tasks.withType(JavaCompile).configureEach {
-	options.compilerArgs << "-Xlint:deprecation"
+    options.compilerArgs << "-Xlint:deprecation"
+    options.compilerArgs << "-parameters"
 }
 
 def isNonStable = { String version ->

--- a/server/build.gradle
+++ b/server/build.gradle
@@ -38,6 +38,7 @@ dependencies {
 	implementation "org.springframework.boot:spring-boot-starter-oauth2-resource-server"
 	implementation "org.springframework.boot:spring-boot-starter-thymeleaf"
 	implementation 'org.springframework.boot:spring-boot-starter-actuator'
+	developmentOnly 'org.springframework.boot:spring-boot-devtools'
 
 	// Avoid outdated version of netty to prevent security issues
 	implementation("io.netty:netty-buffer") { version { 				strictly netty_version } }

--- a/server/src/main/java/de/tum/cit/aet/thesis/controller/DashboardController.java
+++ b/server/src/main/java/de/tum/cit/aet/thesis/controller/DashboardController.java
@@ -1,5 +1,6 @@
 package de.tum.cit.aet.thesis.controller;
 
+import de.tum.cit.aet.thesis.security.CurrentUserProvider;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
@@ -19,18 +20,17 @@ import java.util.List;
 @RequestMapping("/v2/dashboard")
 public class DashboardController {
     private final DashboardService dashboardService;
-    private final AuthenticationService authenticationService;
+    private final CurrentUserProvider currentUserProvider;
 
     @Autowired
-    public DashboardController(DashboardService dashboardService, AuthenticationService authenticationService) {
+    public DashboardController(DashboardService dashboardService,
+        CurrentUserProvider currentUserProvider) {
         this.dashboardService = dashboardService;
-        this.authenticationService = authenticationService;
+       this.currentUserProvider = currentUserProvider;
     }
 
     @GetMapping("/tasks")
-    public ResponseEntity<List<TaskDto>> getTasks(JwtAuthenticationToken jwt) {
-        User authenticatedUser = authenticationService.getAuthenticatedUser(jwt);
-
-        return ResponseEntity.ok(dashboardService.getTasks(authenticatedUser));
+    public ResponseEntity<List<TaskDto>> getTasks() {
+        return ResponseEntity.ok(dashboardService.getTasks(currentUserProvider.getUser()));
     }
 }

--- a/server/src/main/java/de/tum/cit/aet/thesis/controller/PublishedPresentationController.java
+++ b/server/src/main/java/de/tum/cit/aet/thesis/controller/PublishedPresentationController.java
@@ -25,7 +25,7 @@ public class PublishedPresentationController {
 
     @GetMapping()
     public ResponseEntity<PaginationDto<PublishedPresentationDto>> getPresentations(
-            @RequestParam(required = false, defaultValue = "false") Boolean includeDrafts,
+            @RequestParam(required = false, defaultValue = "false") boolean includeDrafts,
             @RequestParam(required = false, defaultValue = "0") Integer page,
             @RequestParam(required = false, defaultValue = "50") Integer limit,
             @RequestParam(required = false, defaultValue = "scheduledAt") String sortBy,

--- a/server/src/main/java/de/tum/cit/aet/thesis/controller/PublishedThesisController.java
+++ b/server/src/main/java/de/tum/cit/aet/thesis/controller/PublishedThesisController.java
@@ -39,6 +39,7 @@ public class PublishedThesisController {
     ) {
         Page<Thesis> theses = thesisService.getAll(
                 null,
+                false,
                 Set.of(ThesisVisibility.PUBLIC),
                 null,
                 new ThesisState[]{ThesisState.FINISHED},

--- a/server/src/main/java/de/tum/cit/aet/thesis/controller/ResearchGroupController.java
+++ b/server/src/main/java/de/tum/cit/aet/thesis/controller/ResearchGroupController.java
@@ -119,4 +119,14 @@ public class ResearchGroupController {
 
     return ResponseEntity.noContent().build();
   }
+
+  @PutMapping("/{researchGroupId}/assign/{userId}")
+  @PreAuthorize("hasRole('admin')")
+  public ResponseEntity<Void> assignUserToResearchGroup(
+      @PathVariable("researchGroupId") UUID researchGroupId,
+      @PathVariable("userId") UUID userId
+  ) {
+    researchGroupService.assignUserToResearchGroup(userId, researchGroupId);
+    return ResponseEntity.noContent().build();
+  }
 }

--- a/server/src/main/java/de/tum/cit/aet/thesis/controller/ResearchGroupController.java
+++ b/server/src/main/java/de/tum/cit/aet/thesis/controller/ResearchGroupController.java
@@ -29,13 +29,10 @@ import org.springframework.web.bind.annotation.RestController;
 public class ResearchGroupController {
 
   private final ResearchGroupService researchGroupService;
-  private final AuthenticationService authenticationService;
 
   @Autowired
-  public ResearchGroupController(ResearchGroupService researchGroupService,
-      AuthenticationService authenticationService) {
+  public ResearchGroupController(ResearchGroupService researchGroupService) {
     this.researchGroupService = researchGroupService;
-    this.authenticationService = authenticationService;
   }
 
   @GetMapping
@@ -47,13 +44,9 @@ public class ResearchGroupController {
       @RequestParam(required = false, defaultValue = "0") Integer page,
       @RequestParam(required = false, defaultValue = "50") Integer limit,
       @RequestParam(required = false, defaultValue = "name") String sortBy,
-      @RequestParam(required = false, defaultValue = "desc") String sortOrder,
-      JwtAuthenticationToken jwt
+      @RequestParam(required = false, defaultValue = "desc") String sortOrder
   ) {
-    User authenticatedUser = authenticationService.getAuthenticatedUser(jwt);
-
     Page<ResearchGroup> researchGroups = researchGroupService.getAll(
-        authenticatedUser,
         heads,
         campuses,
         includeArchived,
@@ -70,11 +63,9 @@ public class ResearchGroupController {
 
   @GetMapping("/{researchGroupId}")
   public ResponseEntity<ResearchGroupDto> getResearchGroup(
-      @PathVariable("researchGroupId") UUID researchGroupId,
-      JwtAuthenticationToken jwt
+      @PathVariable("researchGroupId") UUID researchGroupId
   ) {
-    User authenticatedUser = authenticationService.getAuthenticatedUser(jwt);
-    ResearchGroup researchGroup = researchGroupService.findById(authenticatedUser, researchGroupId);
+    ResearchGroup researchGroup = researchGroupService.findById(researchGroupId);
 
     return ResponseEntity.ok(ResearchGroupDto.fromResearchGroupEntity(researchGroup));
   }
@@ -82,13 +73,9 @@ public class ResearchGroupController {
   @PostMapping
   @PreAuthorize("hasRole('admin')")
   public ResponseEntity<ResearchGroupDto> createResearchGroup(
-      @RequestBody CreateResearchGroupPayload payload,
-      JwtAuthenticationToken jwt
+      @RequestBody CreateResearchGroupPayload payload
   ) {
-    User authenticatedUser = authenticationService.getAuthenticatedUser(jwt);
-
     ResearchGroup researchGroup = researchGroupService.createResearchGroup(
-        authenticatedUser,
         RequestValidator.validateNotNull(payload.headId()),
         RequestValidator.validateNotNull(payload.name()),
         payload.abbreviation(),
@@ -104,14 +91,11 @@ public class ResearchGroupController {
   @PreAuthorize("hasRole('admin')")
   public ResponseEntity<ResearchGroupDto> updateResearchGroup(
       @PathVariable("researchGroupId") UUID researchGroupId,
-      @RequestBody CreateResearchGroupPayload payload,
-      JwtAuthenticationToken jwt
+      @RequestBody CreateResearchGroupPayload payload
   ) {
-    User authenticatedUser = authenticationService.getAuthenticatedUser(jwt);
-    ResearchGroup researchGroup = researchGroupService.findById(authenticatedUser, researchGroupId);
+    ResearchGroup researchGroup = researchGroupService.findById(researchGroupId);
 
     researchGroup = researchGroupService.updateResearchGroup(
-        authenticatedUser,
         researchGroup,
         RequestValidator.validateNotNull(payload.headId()),
         RequestValidator.validateNotNull(payload.name()),
@@ -130,9 +114,8 @@ public class ResearchGroupController {
       @PathVariable("researchGroupId") UUID researchGroupId,
       JwtAuthenticationToken jwt
   ) {
-    User authenticatedUser = authenticationService.getAuthenticatedUser(jwt);
-    ResearchGroup researchGroup = researchGroupService.findById(authenticatedUser, researchGroupId);
-    researchGroupService.archiveResearchGroup(authenticatedUser, researchGroup);
+    ResearchGroup researchGroup = researchGroupService.findById(researchGroupId);
+    researchGroupService.archiveResearchGroup(researchGroup);
 
     return ResponseEntity.noContent().build();
   }

--- a/server/src/main/java/de/tum/cit/aet/thesis/controller/ResearchGroupController.java
+++ b/server/src/main/java/de/tum/cit/aet/thesis/controller/ResearchGroupController.java
@@ -47,9 +47,13 @@ public class ResearchGroupController {
       @RequestParam(required = false, defaultValue = "0") Integer page,
       @RequestParam(required = false, defaultValue = "50") Integer limit,
       @RequestParam(required = false, defaultValue = "name") String sortBy,
-      @RequestParam(required = false, defaultValue = "desc") String sortOrder
+      @RequestParam(required = false, defaultValue = "desc") String sortOrder,
+      JwtAuthenticationToken jwt
   ) {
+    User authenticatedUser = authenticationService.getAuthenticatedUser(jwt);
+
     Page<ResearchGroup> researchGroups = researchGroupService.getAll(
+        authenticatedUser,
         heads,
         campuses,
         includeArchived,
@@ -66,8 +70,11 @@ public class ResearchGroupController {
 
   @GetMapping("/{researchGroupId}")
   public ResponseEntity<ResearchGroupDto> getResearchGroup(
-      @PathVariable("researchGroupId") UUID researchGroupId) {
-    ResearchGroup researchGroup = researchGroupService.findById(researchGroupId);
+      @PathVariable("researchGroupId") UUID researchGroupId,
+      JwtAuthenticationToken jwt
+  ) {
+    User authenticatedUser = authenticationService.getAuthenticatedUser(jwt);
+    ResearchGroup researchGroup = researchGroupService.findById(authenticatedUser, researchGroupId);
 
     return ResponseEntity.ok(ResearchGroupDto.fromResearchGroupEntity(researchGroup));
   }
@@ -101,7 +108,7 @@ public class ResearchGroupController {
       JwtAuthenticationToken jwt
   ) {
     User authenticatedUser = authenticationService.getAuthenticatedUser(jwt);
-    ResearchGroup researchGroup = researchGroupService.findById(researchGroupId);
+    ResearchGroup researchGroup = researchGroupService.findById(authenticatedUser, researchGroupId);
 
     researchGroup = researchGroupService.updateResearchGroup(
         authenticatedUser,
@@ -124,7 +131,7 @@ public class ResearchGroupController {
       JwtAuthenticationToken jwt
   ) {
     User authenticatedUser = authenticationService.getAuthenticatedUser(jwt);
-    ResearchGroup researchGroup = researchGroupService.findById(researchGroupId);
+    ResearchGroup researchGroup = researchGroupService.findById(authenticatedUser, researchGroupId);
     researchGroupService.archiveResearchGroup(authenticatedUser, researchGroup);
 
     return ResponseEntity.noContent().build();

--- a/server/src/main/java/de/tum/cit/aet/thesis/controller/ThesisController.java
+++ b/server/src/main/java/de/tum/cit/aet/thesis/controller/ThesisController.java
@@ -1,6 +1,8 @@
 package de.tum.cit.aet.thesis.controller;
 
+import de.tum.cit.aet.thesis.security.CurrentUserProvider;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.io.Resource;
 import org.springframework.data.domain.Page;
@@ -10,7 +12,6 @@ import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.access.prepost.PreAuthorize;
-import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationToken;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 import de.tum.cit.aet.thesis.constants.*;
@@ -19,7 +20,6 @@ import de.tum.cit.aet.thesis.dto.PaginationDto;
 import de.tum.cit.aet.thesis.dto.ThesisCommentDto;
 import de.tum.cit.aet.thesis.dto.ThesisDto;
 import de.tum.cit.aet.thesis.entity.*;
-import de.tum.cit.aet.thesis.service.AuthenticationService;
 import de.tum.cit.aet.thesis.service.ThesisCommentService;
 import de.tum.cit.aet.thesis.service.ThesisPresentationService;
 import de.tum.cit.aet.thesis.service.ThesisService;
@@ -34,16 +34,21 @@ import java.util.concurrent.TimeUnit;
 @RequestMapping("/v2/theses")
 public class ThesisController {
     private final ThesisService thesisService;
-    private final AuthenticationService authenticationService;
     private final ThesisCommentService thesisCommentService;
     private final ThesisPresentationService thesisPresentationService;
+    private final ObjectProvider<CurrentUserProvider> currentUserProviderProvider;
 
     @Autowired
-    public ThesisController(ThesisService thesisService, AuthenticationService authenticationService, ThesisCommentService thesisCommentService, ThesisPresentationService thesisPresentationService) {
+    public ThesisController(ThesisService thesisService, ThesisCommentService thesisCommentService, ThesisPresentationService thesisPresentationService,
+        ObjectProvider<CurrentUserProvider> currentUserProviderProvider) {
         this.thesisService = thesisService;
-        this.authenticationService = authenticationService;
         this.thesisCommentService = thesisCommentService;
         this.thesisPresentationService = thesisPresentationService;
+        this.currentUserProviderProvider = currentUserProviderProvider;
+    }
+
+    private CurrentUserProvider currentUserProvider() {
+        return currentUserProviderProvider.getObject();
     }
 
     @GetMapping
@@ -51,16 +56,14 @@ public class ThesisController {
             @RequestParam(required = false) String search,
             @RequestParam(required = false) ThesisState[] state,
             @RequestParam(required = false) String[] type,
-            @RequestParam(required = false, defaultValue = "false") Boolean fetchAll,
+            @RequestParam(required = false, defaultValue = "false") boolean fetchAll,
             @RequestParam(required = false, defaultValue = "0") Integer page,
             @RequestParam(required = false, defaultValue = "50") Integer limit,
             @RequestParam(required = false, defaultValue = "createdAt") String sortBy,
-            @RequestParam(required = false, defaultValue = "desc") String sortOrder,
-            JwtAuthenticationToken jwt
+            @RequestParam(required = false, defaultValue = "desc") String sortOrder
     ) {
-        User authenticatedUser = authenticationService.getAuthenticatedUser(jwt);
-
-        UUID userId = authenticatedUser.getId();
+        User currentUser = currentUserProvider().getUser();
+        UUID userId = currentUser.getId();
         Set<ThesisVisibility> visibilities = Set.of(
                 ThesisVisibility.PUBLIC,
                 ThesisVisibility.STUDENT,
@@ -71,11 +74,11 @@ public class ThesisController {
         if (fetchAll) {
             userId = null;
 
-            if (authenticatedUser.hasAnyGroup("admin")) {
+            if (currentUserProvider().isAdmin()) {
                 visibilities = null;
-            } else if (authenticatedUser.hasAnyGroup("advisor", "supervisor")) {
+            } else if (currentUserProvider().isAdvisor() || currentUserProvider().isSupervisor()) {
                 visibilities = Set.of(ThesisVisibility.PUBLIC, ThesisVisibility.STUDENT, ThesisVisibility.INTERNAL);
-            } else if (authenticatedUser.hasAnyGroup("student")) {
+            } else if (currentUserProvider().isStudent()) {
                 visibilities = Set.of(ThesisVisibility.PUBLIC, ThesisVisibility.STUDENT);
             } else {
                 visibilities = Set.of(ThesisVisibility.PUBLIC);
@@ -95,31 +98,29 @@ public class ThesisController {
         );
 
         return ResponseEntity.ok(PaginationDto.fromSpringPage(
-                theses.map(thesis -> ThesisDto.fromThesisEntity(thesis, thesis.hasAdvisorAccess(authenticatedUser), thesis.hasStudentAccess(authenticatedUser)))
+                theses.map(thesis -> ThesisDto.fromThesisEntity(thesis, thesis.hasAdvisorAccess(currentUser), thesis.hasStudentAccess(currentUser)))
         ));
     }
 
     @GetMapping("/{thesisId}")
-    public ResponseEntity<ThesisDto> getThesis(@PathVariable UUID thesisId, JwtAuthenticationToken jwt) {
-        User authenticatedUser = authenticationService.getAuthenticatedUser(jwt);
+    public ResponseEntity<ThesisDto> getThesis(@PathVariable UUID thesisId) {
+        User currentUser = currentUserProvider().getUser();
         Thesis thesis = thesisService.findById(thesisId);
 
-        if (!thesis.hasReadAccess(authenticatedUser)) {
+        if (!thesis.hasReadAccess(currentUser)) {
             throw new AccessDeniedException("You do not have the required permissions to view this thesis");
         }
 
-        return ResponseEntity.ok(ThesisDto.fromThesisEntity(thesis, thesis.hasAdvisorAccess(authenticatedUser), thesis.hasStudentAccess(authenticatedUser)));
+        return ResponseEntity.ok(ThesisDto.fromThesisEntity(thesis, thesis.hasAdvisorAccess(currentUser), thesis.hasStudentAccess(currentUser)));
     }
 
     @PostMapping
     @PreAuthorize("hasAnyRole('admin', 'advisor', 'supervisor')")
     public ResponseEntity<ThesisDto> createThesis(
-            @RequestBody CreateThesisPayload payload,
-            JwtAuthenticationToken jwt
+            @RequestBody CreateThesisPayload payload
     ) {
-        User authenticatedUser = authenticationService.getAuthenticatedUser(jwt);
+        User currentUser = currentUserProvider().getUser();
         Thesis thesis = thesisService.createThesis(
-                authenticatedUser,
                 RequestValidator.validateStringMaxLength(payload.thesisTitle(), StringLimits.THESIS_TITLE.getLimit()),
                 RequestValidator.validateStringMaxLength(payload.thesisType(), StringLimits.SHORTTEXT.getLimit()),
                 RequestValidator.validateStringMaxLength(payload.language(), StringLimits.SHORTTEXT.getLimit()),
@@ -129,25 +130,22 @@ public class ThesisController {
                 null,
                 true
         );
-
-        return ResponseEntity.ok(ThesisDto.fromThesisEntity(thesis, thesis.hasAdvisorAccess(authenticatedUser), thesis.hasStudentAccess(authenticatedUser)));
+        return ResponseEntity.ok(ThesisDto.fromThesisEntity(thesis, thesis.hasAdvisorAccess(currentUser), thesis.hasStudentAccess(currentUser)));
     }
 
     @PutMapping("/{thesisId}")
     public ResponseEntity<ThesisDto> updateThesisConfig(
             @PathVariable UUID thesisId,
-            @RequestBody UpdateThesisPayload payload,
-            JwtAuthenticationToken jwt
+            @RequestBody UpdateThesisPayload payload
     ) {
-        User authenticatedUser = authenticationService.getAuthenticatedUser(jwt);
+        User currentUser = currentUserProvider().getUser();
         Thesis thesis = thesisService.findById(thesisId);
 
-        if (!thesis.hasAdvisorAccess(authenticatedUser)) {
+        if (!thesis.hasAdvisorAccess(currentUser)) {
             throw new AccessDeniedException("You need to be an advisor of this thesis to update the thesis");
         }
 
         thesis = thesisService.updateThesis(
-                authenticatedUser,
                 thesis,
                 RequestValidator.validateStringMaxLength(payload.thesisTitle(), StringLimits.THESIS_TITLE.getLimit()),
                 RequestValidator.validateStringMaxLength(payload.thesisType(), StringLimits.SHORTTEXT.getLimit()),
@@ -162,36 +160,34 @@ public class ThesisController {
                 RequestValidator.validateNotNull(payload.states())
         );
 
-        return ResponseEntity.ok(ThesisDto.fromThesisEntity(thesis, thesis.hasAdvisorAccess(authenticatedUser), thesis.hasStudentAccess(authenticatedUser)));
+        return ResponseEntity.ok(ThesisDto.fromThesisEntity(thesis, thesis.hasAdvisorAccess(currentUser), thesis.hasStudentAccess(currentUser)));
     }
 
     @DeleteMapping("/{thesisId}")
     public ResponseEntity<ThesisDto> closeThesis(
-            @PathVariable UUID thesisId,
-            JwtAuthenticationToken jwt
+            @PathVariable UUID thesisId
     ) {
-        User authenticatedUser = authenticationService.getAuthenticatedUser(jwt);
+        User currentUser = currentUserProvider().getUser();
         Thesis thesis = thesisService.findById(thesisId);
 
-        if (!thesis.hasAdvisorAccess(authenticatedUser)) {
+        if (!thesis.hasAdvisorAccess(currentUser)) {
             throw new AccessDeniedException("You do not have the required permissions to view this thesis");
         }
 
-        thesis = thesisService.closeThesis(authenticatedUser, thesis);
+        thesis = thesisService.closeThesis(thesis);
 
-        return ResponseEntity.ok(ThesisDto.fromThesisEntity(thesis, thesis.hasAdvisorAccess(authenticatedUser), thesis.hasStudentAccess(authenticatedUser)));
+        return ResponseEntity.ok(ThesisDto.fromThesisEntity(thesis, thesis.hasAdvisorAccess(currentUser), thesis.hasStudentAccess(currentUser)));
     }
 
     @PutMapping("/{thesisId}/info")
     public ResponseEntity<ThesisDto> updateThesisInfo(
             @PathVariable UUID thesisId,
-            @RequestBody UpdateThesisInfoPayload payload,
-            JwtAuthenticationToken jwt
+            @RequestBody UpdateThesisInfoPayload payload
     ) {
-        User authenticatedUser = authenticationService.getAuthenticatedUser(jwt);
+        User currentUser = currentUserProvider().getUser();
         Thesis thesis = thesisService.findById(thesisId);
 
-        if (!thesis.hasStudentAccess(authenticatedUser)) {
+        if (!thesis.hasStudentAccess(currentUser)) {
             throw new AccessDeniedException("You need to be a student of this thesis to update the abstract and info");
         }
 
@@ -207,19 +203,18 @@ public class ThesisController {
                 RequestValidator.validateNotNull(payload.secondaryTitles())
         );
 
-        return ResponseEntity.ok(ThesisDto.fromThesisEntity(thesis, thesis.hasAdvisorAccess(authenticatedUser), thesis.hasStudentAccess(authenticatedUser)));
+        return ResponseEntity.ok(ThesisDto.fromThesisEntity(thesis, thesis.hasAdvisorAccess(currentUser), thesis.hasStudentAccess(currentUser)));
     }
 
     @PutMapping("/{thesisId}/credits")
     public ResponseEntity<ThesisDto> updateThesisCredits(
             @PathVariable UUID thesisId,
-            @RequestBody UpdateThesisCreditsPayload payload,
-            JwtAuthenticationToken jwt
+            @RequestBody UpdateThesisCreditsPayload payload
     ) {
-        User authenticatedUser = authenticationService.getAuthenticatedUser(jwt);
+        User currentUser = currentUserProvider().getUser();
         Thesis thesis = thesisService.findById(thesisId);
 
-        if (!thesis.hasAdvisorAccess(authenticatedUser)) {
+        if (!thesis.hasAdvisorAccess(currentUser)) {
             throw new AccessDeniedException("You need to be an advisor of this thesis to update the student credits");
         }
 
@@ -228,7 +223,7 @@ public class ThesisController {
                 payload.credits()
         );
 
-        return ResponseEntity.ok(ThesisDto.fromThesisEntity(thesis, thesis.hasAdvisorAccess(authenticatedUser), thesis.hasStudentAccess(authenticatedUser)));
+        return ResponseEntity.ok(ThesisDto.fromThesisEntity(thesis, thesis.hasAdvisorAccess(currentUser), thesis.hasStudentAccess(currentUser)));
     }
 
     /* FEEDBACK ENDPOINTS */
@@ -236,60 +231,56 @@ public class ThesisController {
     public ResponseEntity<ThesisDto> completeFeedback(
             @PathVariable UUID thesisId,
             @PathVariable UUID feedbackId,
-            @PathVariable String action,
-            JwtAuthenticationToken jwt
+            @PathVariable String action
     ) {
-        User authenticatedUser = authenticationService.getAuthenticatedUser(jwt);
+        User currentUser = currentUserProvider().getUser();
         Thesis thesis = thesisService.findById(thesisId);
 
-        if (!thesis.hasStudentAccess(authenticatedUser)) {
+        if (!thesis.hasStudentAccess(currentUser)) {
             throw new AccessDeniedException("You need to be a student of this thesis to complete a feedback item");
         }
 
         thesis = thesisService.completeFeedback(thesis, feedbackId, action.equals("complete"));
 
-        return ResponseEntity.ok(ThesisDto.fromThesisEntity(thesis, thesis.hasAdvisorAccess(authenticatedUser), thesis.hasStudentAccess(authenticatedUser)));
+        return ResponseEntity.ok(ThesisDto.fromThesisEntity(thesis, thesis.hasAdvisorAccess(currentUser), thesis.hasStudentAccess(currentUser)));
     }
 
     @DeleteMapping("/{thesisId}/feedback/{feedbackId}")
     public ResponseEntity<ThesisDto> deleteFeedback(
             @PathVariable UUID thesisId,
-            @PathVariable UUID feedbackId,
-            JwtAuthenticationToken jwt
+            @PathVariable UUID feedbackId
     ) {
-        User authenticatedUser = authenticationService.getAuthenticatedUser(jwt);
+        User currentUser = currentUserProvider().getUser();
         Thesis thesis = thesisService.findById(thesisId);
 
-        if (!thesis.hasAdvisorAccess(authenticatedUser)) {
+        if (!thesis.hasAdvisorAccess(currentUser)) {
             throw new AccessDeniedException("You need to be a advisor of this thesis to delete a feedback item");
         }
 
         thesis = thesisService.deleteFeedback(thesis, feedbackId);
 
-        return ResponseEntity.ok(ThesisDto.fromThesisEntity(thesis, thesis.hasAdvisorAccess(authenticatedUser), thesis.hasStudentAccess(authenticatedUser)));
+        return ResponseEntity.ok(ThesisDto.fromThesisEntity(thesis, thesis.hasAdvisorAccess(currentUser), thesis.hasStudentAccess(currentUser)));
     }
 
     @PostMapping("/{thesisId}/feedback")
     public ResponseEntity<ThesisDto> requestChanges(
             @PathVariable UUID thesisId,
-            @RequestBody RequestChangesPayload payload,
-            JwtAuthenticationToken jwt
+            @RequestBody RequestChangesPayload payload
     ) {
-        User authenticatedUser = authenticationService.getAuthenticatedUser(jwt);
+        User currentUser = currentUserProvider().getUser();
         Thesis thesis = thesisService.findById(thesisId);
 
-        if (!thesis.hasAdvisorAccess(authenticatedUser)) {
+        if (!thesis.hasAdvisorAccess(currentUser)) {
             throw new AccessDeniedException("You need to be an advisor of this thesis to request changes");
         }
 
         thesis = thesisService.requestChanges(
-                authenticatedUser,
                 thesis,
                 RequestValidator.validateNotNull(payload.type()),
                 RequestValidator.validateNotNull(payload.requestedChanges())
         );
 
-        return ResponseEntity.ok(ThesisDto.fromThesisEntity(thesis, thesis.hasAdvisorAccess(authenticatedUser), thesis.hasStudentAccess(authenticatedUser)));
+        return ResponseEntity.ok(ThesisDto.fromThesisEntity(thesis, thesis.hasAdvisorAccess(currentUser), thesis.hasStudentAccess(currentUser)));
     }
 
     /* PROPOSAL ENDPOINTS */
@@ -297,13 +288,12 @@ public class ThesisController {
     @GetMapping("/{thesisId}/proposal/{proposalId}")
     public ResponseEntity<Resource> getProposalFile(
             @PathVariable UUID thesisId,
-            @PathVariable UUID proposalId,
-            JwtAuthenticationToken jwt
+            @PathVariable UUID proposalId
     ) {
-        User authenticatedUser = authenticationService.getAuthenticatedUser(jwt);
+        User currentUser = currentUserProvider().getUser();
         Thesis thesis = thesisService.findById(thesisId);
 
-        if (!thesis.hasReadAccess(authenticatedUser)) {
+        if (!thesis.hasReadAccess(currentUser)) {
             throw new AccessDeniedException("You do not have the required permissions to view this thesis");
         }
 
@@ -319,112 +309,106 @@ public class ThesisController {
     @DeleteMapping("/{thesisId}/proposal/{proposalId}")
     public ResponseEntity<ThesisDto> deleteProposal(
             @PathVariable UUID thesisId,
-            @PathVariable UUID proposalId,
-            JwtAuthenticationToken jwt
+            @PathVariable UUID proposalId
     ) {
-        User authenticatedUser = authenticationService.getAuthenticatedUser(jwt);
+        User currentUser = currentUserProvider().getUser();
         Thesis thesis = thesisService.findById(thesisId);
 
-        if (!thesis.hasAdvisorAccess(authenticatedUser)) {
+        if (!thesis.hasAdvisorAccess(currentUser)) {
             throw new AccessDeniedException("You do not have the required permissions to delete this proposal");
         }
 
         thesis = thesisService.deleteProposal(thesis, proposalId);
 
-        return ResponseEntity.ok(ThesisDto.fromThesisEntity(thesis, thesis.hasAdvisorAccess(authenticatedUser), thesis.hasStudentAccess(authenticatedUser)));
+        return ResponseEntity.ok(ThesisDto.fromThesisEntity(thesis, thesis.hasAdvisorAccess(currentUser), thesis.hasStudentAccess(currentUser)));
     }
 
     @PostMapping("/{thesisId}/proposal")
     public ResponseEntity<ThesisDto> uploadProposal(
             @PathVariable UUID thesisId,
-            @RequestPart("proposal") MultipartFile proposalFile,
-            JwtAuthenticationToken jwt
+            @RequestPart("proposal") MultipartFile proposalFile
     ) {
-        User authenticatedUser = authenticationService.getAuthenticatedUser(jwt);
+        User currentUser = currentUserProvider().getUser();
         Thesis thesis = thesisService.findById(thesisId);
 
-        if (!thesis.hasStudentAccess(authenticatedUser)) {
+        if (!thesis.hasStudentAccess(currentUser)) {
             throw new AccessDeniedException("You need to be a student of this thesis to add a proposal");
         }
 
-        if (thesis.getState() != ThesisState.PROPOSAL && !thesis.hasAdvisorAccess(authenticatedUser)) {
+        if (thesis.getState() != ThesisState.PROPOSAL && !thesis.hasAdvisorAccess(currentUser)) {
             throw new AccessDeniedException("Only advisors can upload a new proposal if thesis state is not PROPOSAL");
         }
 
-        thesis = thesisService.uploadProposal(authenticatedUser, thesis, RequestValidator.validateNotNull(proposalFile));
+        thesis = thesisService.uploadProposal(thesis, RequestValidator.validateNotNull(proposalFile));
 
-        return ResponseEntity.ok(ThesisDto.fromThesisEntity(thesis, thesis.hasAdvisorAccess(authenticatedUser), thesis.hasStudentAccess(authenticatedUser)));
+        return ResponseEntity.ok(ThesisDto.fromThesisEntity(thesis, thesis.hasAdvisorAccess(currentUser), thesis.hasStudentAccess(currentUser)));
     }
 
     @PutMapping("/{thesisId}/proposal/accept")
     public ResponseEntity<ThesisDto> acceptProposal(
-            @PathVariable UUID thesisId,
-            JwtAuthenticationToken jwt
+            @PathVariable UUID thesisId
     ) {
-        User authenticatedUser = authenticationService.getAuthenticatedUser(jwt);
+        User currentUser = currentUserProvider().getUser();
         Thesis thesis = thesisService.findById(thesisId);
 
-        if (!thesis.hasAdvisorAccess(authenticatedUser)) {
+        if (!thesis.hasAdvisorAccess(currentUser)) {
             throw new AccessDeniedException("You need to be an advisor of this thesis to accept a proposal");
         }
 
-        thesis = thesisService.acceptProposal(authenticatedUser, thesis);
+        thesis = thesisService.acceptProposal(thesis);
 
-        return ResponseEntity.ok(ThesisDto.fromThesisEntity(thesis, thesis.hasAdvisorAccess(authenticatedUser), thesis.hasStudentAccess(authenticatedUser)));
+        return ResponseEntity.ok(ThesisDto.fromThesisEntity(thesis, thesis.hasAdvisorAccess(currentUser), thesis.hasStudentAccess(currentUser)));
     }
 
     /* WRITING ENDPOINTS */
 
     @PutMapping("/{thesisId}/thesis/final-submission")
     public ResponseEntity<ThesisDto> submitThesis(
-            @PathVariable UUID thesisId,
-            JwtAuthenticationToken jwt
+            @PathVariable UUID thesisId
     ) {
-        User authenticatedUser = authenticationService.getAuthenticatedUser(jwt);
+        User currentUser = currentUserProvider().getUser();
         Thesis thesis = thesisService.findById(thesisId);
 
-        if (!thesis.hasStudentAccess(authenticatedUser)) {
+        if (!thesis.hasStudentAccess(currentUser)) {
             throw new AccessDeniedException("You need to be a student of the thesis to do the final submission");
         }
 
         thesis = thesisService.submitThesis(thesis);
 
-        return ResponseEntity.ok(ThesisDto.fromThesisEntity(thesis, thesis.hasAdvisorAccess(authenticatedUser), thesis.hasStudentAccess(authenticatedUser)));
+        return ResponseEntity.ok(ThesisDto.fromThesisEntity(thesis, thesis.hasAdvisorAccess(currentUser), thesis.hasStudentAccess(currentUser)));
     }
 
     @PostMapping("/{thesisId}/files")
     public ResponseEntity<ThesisDto> uploadThesisFile(
             @PathVariable UUID thesisId,
             @RequestPart("type") String type,
-            @RequestPart("file") MultipartFile file,
-            JwtAuthenticationToken jwt
+            @RequestPart("file") MultipartFile file
     ) {
-        User authenticatedUser = authenticationService.getAuthenticatedUser(jwt);
+        User currentUser = currentUserProvider().getUser();
         Thesis thesis = thesisService.findById(thesisId);
 
-        if (!thesis.hasStudentAccess(authenticatedUser)) {
+        if (!thesis.hasStudentAccess(currentUser)) {
             throw new AccessDeniedException("You need to be a student of this thesis to upload thesis files");
         }
 
-        if (thesis.getState() != ThesisState.WRITING && !thesis.hasAdvisorAccess(authenticatedUser)) {
+        if (thesis.getState() != ThesisState.WRITING && !thesis.hasAdvisorAccess(currentUser)) {
             throw new AccessDeniedException("Only advisors can upload a new file if thesis state is not WRITING");
         }
 
-        thesis = thesisService.uploadThesisFile(authenticatedUser, thesis, type, RequestValidator.validateNotNull(file));
+        thesis = thesisService.uploadThesisFile(thesis, type, RequestValidator.validateNotNull(file));
 
-        return ResponseEntity.ok(ThesisDto.fromThesisEntity(thesis, thesis.hasAdvisorAccess(authenticatedUser), thesis.hasStudentAccess(authenticatedUser)));
+        return ResponseEntity.ok(ThesisDto.fromThesisEntity(thesis, thesis.hasAdvisorAccess(currentUser), thesis.hasStudentAccess(currentUser)));
     }
 
     @GetMapping("/{thesisId}/files/{fileId}")
     public ResponseEntity<Resource> getThesisFile(
             @PathVariable UUID thesisId,
-            @PathVariable UUID fileId,
-            JwtAuthenticationToken jwt
+            @PathVariable UUID fileId
     ) {
-        User authenticatedUser = authenticationService.getAuthenticatedUser(jwt);
+        User currentUser = currentUserProvider().getUser();
         Thesis thesis = thesisService.findById(thesisId);
 
-        if (!thesis.hasReadAccess(authenticatedUser)) {
+        if (!thesis.hasReadAccess(currentUser)) {
             throw new AccessDeniedException("You do not have the required permissions to view this thesis");
         }
 
@@ -440,36 +424,33 @@ public class ThesisController {
     @DeleteMapping("/{thesisId}/files/{fileId}")
     public ResponseEntity<ThesisDto> deleteThesisFile(
             @PathVariable UUID thesisId,
-            @PathVariable UUID fileId,
-            JwtAuthenticationToken jwt
+            @PathVariable UUID fileId
     ) {
-        User authenticatedUser = authenticationService.getAuthenticatedUser(jwt);
+        User currentUser = currentUserProvider().getUser();
         Thesis thesis = thesisService.findById(thesisId);
 
-        if (!thesis.hasAdvisorAccess(authenticatedUser)) {
+        if (!thesis.hasAdvisorAccess(currentUser)) {
             throw new AccessDeniedException("You do not have the required permissions to delete this file");
         }
 
         thesis = thesisService.deleteThesisFile(thesis, fileId);
 
-        return ResponseEntity.ok(ThesisDto.fromThesisEntity(thesis, thesis.hasAdvisorAccess(authenticatedUser), thesis.hasStudentAccess(authenticatedUser)));
+        return ResponseEntity.ok(ThesisDto.fromThesisEntity(thesis, thesis.hasAdvisorAccess(currentUser), thesis.hasStudentAccess(currentUser)));
     }
 
     @PostMapping("/{thesisId}/presentations")
     public ResponseEntity<ThesisDto> createPresentation(
             @PathVariable UUID thesisId,
-            @RequestBody ReplacePresentationPayload payload,
-            JwtAuthenticationToken jwt
+            @RequestBody ReplacePresentationPayload payload
     ) {
-        User authenticatedUser = authenticationService.getAuthenticatedUser(jwt);
+        User currentUser = currentUserProvider().getUser();
         Thesis thesis = thesisService.findById(thesisId);
 
-        if (!thesis.hasStudentAccess(authenticatedUser)) {
+        if (!thesis.hasStudentAccess(currentUser)) {
             throw new AccessDeniedException("You need to be a student of this thesis to create a presentation");
         }
 
         thesis = thesisPresentationService.createPresentation(
-                authenticatedUser,
                 thesis,
                 RequestValidator.validateNotNull(payload.type()),
                 RequestValidator.validateNotNull(payload.visibility()),
@@ -479,25 +460,24 @@ public class ThesisController {
                 RequestValidator.validateNotNull(payload.date())
         );
 
-        return ResponseEntity.ok(ThesisDto.fromThesisEntity(thesis, thesis.hasAdvisorAccess(authenticatedUser), thesis.hasStudentAccess(authenticatedUser)));
+        return ResponseEntity.ok(ThesisDto.fromThesisEntity(thesis, thesis.hasAdvisorAccess(currentUser), thesis.hasStudentAccess(currentUser)));
     }
 
     @PutMapping("/{thesisId}/presentations/{presentationId}")
     public ResponseEntity<ThesisDto> updatePresentation(
             @PathVariable UUID thesisId,
             @PathVariable UUID presentationId,
-            @RequestBody ReplacePresentationPayload payload,
-            JwtAuthenticationToken jwt
+            @RequestBody ReplacePresentationPayload payload
     ) {
-        User authenticatedUser = authenticationService.getAuthenticatedUser(jwt);
+        User currentUser = currentUserProvider().getUser();
         ThesisPresentation presentation = thesisPresentationService.findById(thesisId, presentationId);
         Thesis thesis = presentation.getThesis();
 
-        if (!thesis.hasStudentAccess(authenticatedUser)) {
+        if (!thesis.hasStudentAccess(currentUser)) {
             throw new AccessDeniedException("You need to be a student of this thesis to update a presentation");
         }
 
-        if (presentation.getState() == ThesisPresentationState.SCHEDULED && !thesis.hasAdvisorAccess(authenticatedUser)) {
+        if (presentation.getState() == ThesisPresentationState.SCHEDULED && !thesis.hasAdvisorAccess(currentUser)) {
             throw new AccessDeniedException("You need to be an advisor of this thesis to update a scheduled presentation");
         }
 
@@ -511,21 +491,20 @@ public class ThesisController {
                 RequestValidator.validateNotNull(payload.date())
         );
 
-        return ResponseEntity.ok(ThesisDto.fromThesisEntity(thesis, thesis.hasAdvisorAccess(authenticatedUser), thesis.hasStudentAccess(authenticatedUser)));
+        return ResponseEntity.ok(ThesisDto.fromThesisEntity(thesis, thesis.hasAdvisorAccess(currentUser), thesis.hasStudentAccess(currentUser)));
     }
 
     @PostMapping("/{thesisId}/presentations/{presentationId}/schedule")
     public ResponseEntity<ThesisDto> schedulePresentation(
             @PathVariable UUID thesisId,
             @PathVariable UUID presentationId,
-            @RequestBody SchedulePresentationPayload payload,
-            JwtAuthenticationToken jwt
+            @RequestBody SchedulePresentationPayload payload
     ) {
-        User authenticatedUser = authenticationService.getAuthenticatedUser(jwt);
+        User currentUser = currentUserProvider().getUser();
         ThesisPresentation presentation = thesisPresentationService.findById(thesisId, presentationId);
         Thesis thesis = presentation.getThesis();
 
-        if (!thesis.hasAdvisorAccess(authenticatedUser)) {
+        if (!thesis.hasAdvisorAccess(currentUser)) {
             throw new AccessDeniedException("You need to be an advisor of this thesis to schedule a presentation");
         }
 
@@ -536,25 +515,24 @@ public class ThesisController {
                 RequestValidator.validateNotNull(payload.optionalAttendees())
         );
 
-        return ResponseEntity.ok(ThesisDto.fromThesisEntity(thesis, thesis.hasAdvisorAccess(authenticatedUser), thesis.hasStudentAccess(authenticatedUser)));
+        return ResponseEntity.ok(ThesisDto.fromThesisEntity(thesis, thesis.hasAdvisorAccess(currentUser), thesis.hasStudentAccess(currentUser)));
     }
 
     @DeleteMapping("/{thesisId}/presentations/{presentationId}")
     public ResponseEntity<ThesisDto> deletePresentation(
             @PathVariable UUID thesisId,
-            @PathVariable UUID presentationId,
-            JwtAuthenticationToken jwt
+            @PathVariable UUID presentationId
     ) {
-        User authenticatedUser = authenticationService.getAuthenticatedUser(jwt);
+        User currentUser = currentUserProvider().getUser();
         ThesisPresentation presentation = thesisPresentationService.findById(thesisId, presentationId);
 
-        if (!presentation.hasManagementAccess(authenticatedUser)) {
+        if (!presentation.hasManagementAccess(currentUser)) {
             throw new AccessDeniedException("You are not allowed to delete this presentation");
         }
 
-        Thesis thesis = thesisPresentationService.deletePresentation(authenticatedUser, presentation);
+        Thesis thesis = thesisPresentationService.deletePresentation(presentation);
 
-        return ResponseEntity.ok(ThesisDto.fromThesisEntity(thesis, thesis.hasAdvisorAccess(authenticatedUser), thesis.hasStudentAccess(authenticatedUser)));
+        return ResponseEntity.ok(ThesisDto.fromThesisEntity(thesis, thesis.hasAdvisorAccess(currentUser), thesis.hasStudentAccess(currentUser)));
     }
 
     @GetMapping("/{thesisId}/comments")
@@ -562,17 +540,16 @@ public class ThesisController {
             @PathVariable UUID thesisId,
             @RequestParam(required = false, defaultValue = "THESIS") ThesisCommentType commentType,
             @RequestParam(required = false, defaultValue = "0") Integer page,
-            @RequestParam(required = false, defaultValue = "50") Integer limit,
-            JwtAuthenticationToken jwt
+            @RequestParam(required = false, defaultValue = "50") Integer limit
     ) {
-        User authenticatedUser = authenticationService.getAuthenticatedUser(jwt);
+        User currentUser = currentUserProvider().getUser();
         Thesis thesis = thesisService.findById(thesisId);
 
-        if (commentType == ThesisCommentType.ADVISOR && !thesis.hasAdvisorAccess(authenticatedUser)) {
+        if (commentType == ThesisCommentType.ADVISOR && !thesis.hasAdvisorAccess(currentUser)) {
             throw new AccessDeniedException("You need to be an advisor of this thesis to view advisor comments");
         }
 
-        if (!thesis.hasReadAccess(authenticatedUser)) {
+        if (!thesis.hasReadAccess(currentUser)) {
             throw new AccessDeniedException("You do not have the required permissions to view comments on this thesis");
         }
 
@@ -585,22 +562,20 @@ public class ThesisController {
     public ResponseEntity<ThesisCommentDto> createComment(
             @PathVariable UUID thesisId,
             @RequestPart("data") PostThesisCommentPayload payload,
-            @RequestPart(value = "file", required = false) MultipartFile file,
-            JwtAuthenticationToken jwt
+            @RequestPart(value = "file", required = false) MultipartFile file
     ) {
-        User authenticatedUser = authenticationService.getAuthenticatedUser(jwt);
+        User currentUser = currentUserProvider().getUser();
         Thesis thesis = thesisService.findById(thesisId);
 
-        if (payload.commentType() == ThesisCommentType.ADVISOR && !thesis.hasAdvisorAccess(authenticatedUser)) {
+        if (payload.commentType() == ThesisCommentType.ADVISOR && !thesis.hasAdvisorAccess(currentUser)) {
             throw new AccessDeniedException("You need to be an advisor of this thesis to add an advisor comment");
         }
 
-        if (!thesis.hasStudentAccess(authenticatedUser)) {
+        if (!thesis.hasStudentAccess(currentUser)) {
             throw new AccessDeniedException("You need to be a student of this thesis to add a comment");
         }
 
         ThesisComment comment = thesisCommentService.postComment(
-                authenticatedUser,
                 thesis,
                 RequestValidator.validateNotNull(payload.commentType()),
                 RequestValidator.validateStringMaxLength(payload.message(), StringLimits.LONGTEXT.getLimit()),
@@ -613,17 +588,16 @@ public class ThesisController {
     @GetMapping("/{thesisId}/comments/{commentId}/file")
     public ResponseEntity<Resource> getCommentFile(
             @PathVariable UUID thesisId,
-            @PathVariable UUID commentId,
-            JwtAuthenticationToken jwt
+            @PathVariable UUID commentId
     ) {
-        User authenticatedUser = authenticationService.getAuthenticatedUser(jwt);
+        User currentUser = currentUserProvider().getUser();
         ThesisComment comment = thesisCommentService.findById(thesisId, commentId);
 
-        if (comment.getType() == ThesisCommentType.ADVISOR && !comment.getThesis().hasAdvisorAccess(authenticatedUser)) {
+        if (comment.getType() == ThesisCommentType.ADVISOR && !comment.getThesis().hasAdvisorAccess(currentUser)) {
             throw new AccessDeniedException("You need to be a advisor of this thesis to view an advisor file");
         }
 
-        if (!comment.getThesis().hasReadAccess(authenticatedUser)) {
+        if (!comment.getThesis().hasReadAccess(currentUser)) {
             throw new AccessDeniedException("You do not have the required permissions to view this comment");
         }
 
@@ -637,13 +611,12 @@ public class ThesisController {
     @DeleteMapping("/{thesisId}/comments/{commentId}")
     public ResponseEntity<ThesisCommentDto> deleteComment(
             @PathVariable UUID thesisId,
-            @PathVariable UUID commentId,
-            JwtAuthenticationToken jwt
+            @PathVariable UUID commentId
     ) {
-        User authenticatedUser = authenticationService.getAuthenticatedUser(jwt);
+        User currentUser = currentUserProvider().getUser();
         ThesisComment comment = thesisCommentService.findById(thesisId, commentId);
 
-        if (!comment.hasManagementAccess(authenticatedUser)) {
+        if (!comment.hasManagementAccess(currentUser)) {
             throw new AccessDeniedException("You are not allowed to delete this comment");
         }
 
@@ -656,13 +629,12 @@ public class ThesisController {
 
     @GetMapping("/{thesisId}/assessment")
     public ResponseEntity<Resource> getAssessmentFile(
-            @PathVariable UUID thesisId,
-            JwtAuthenticationToken jwt
+            @PathVariable UUID thesisId
     ) {
-        User authenticatedUser = authenticationService.getAuthenticatedUser(jwt);
+        User currentUser = currentUserProvider().getUser();
         Thesis thesis = thesisService.findById(thesisId);
 
-        if (!thesis.hasAdvisorAccess(authenticatedUser)) {
+        if (!thesis.hasAdvisorAccess(currentUser)) {
             throw new AccessDeniedException("You need to be a advisor of this thesis to add an assessment");
         }
 
@@ -675,18 +647,16 @@ public class ThesisController {
     @PostMapping("/{thesisId}/assessment")
     public ResponseEntity<ThesisDto> createAssessment(
             @PathVariable UUID thesisId,
-            @RequestBody CreateAssessmentPayload payload,
-            JwtAuthenticationToken jwt
+            @RequestBody CreateAssessmentPayload payload
     ) {
-        User authenticatedUser = authenticationService.getAuthenticatedUser(jwt);
+        User currentUser = currentUserProvider().getUser();
         Thesis thesis = thesisService.findById(thesisId);
 
-        if (!thesis.hasAdvisorAccess(authenticatedUser)) {
+        if (!thesis.hasAdvisorAccess(currentUser)) {
             throw new AccessDeniedException("You need to be a advisor of this thesis to add an assessment");
         }
 
         thesis = thesisService.submitAssessment(
-                authenticatedUser,
                 thesis,
                 RequestValidator.validateStringMaxLength(payload.summary(), StringLimits.UNLIMITED_TEXT.getLimit()),
                 RequestValidator.validateStringMaxLength(payload.positives(), StringLimits.UNLIMITED_TEXT.getLimit()),
@@ -694,7 +664,7 @@ public class ThesisController {
                 RequestValidator.validateStringMaxLength(payload.gradeSuggestion(), StringLimits.THESIS_GRADE.getLimit())
         );
 
-        return ResponseEntity.ok(ThesisDto.fromThesisEntity(thesis, thesis.hasAdvisorAccess(authenticatedUser), thesis.hasStudentAccess(authenticatedUser)));
+        return ResponseEntity.ok(ThesisDto.fromThesisEntity(thesis, thesis.hasAdvisorAccess(currentUser), thesis.hasStudentAccess(currentUser)));
     }
 
     /* GRADE ENDPOINTS */
@@ -702,13 +672,12 @@ public class ThesisController {
     @PostMapping("/{thesisId}/grade")
     public ResponseEntity<ThesisDto> addGrade(
             @PathVariable UUID thesisId,
-            @RequestBody AddThesisGradePayload payload,
-            JwtAuthenticationToken jwt
+            @RequestBody AddThesisGradePayload payload
     ) {
-        User authenticatedUser = authenticationService.getAuthenticatedUser(jwt);
+        User currentUser = currentUserProvider().getUser();
         Thesis thesis = thesisService.findById(thesisId);
 
-        if (!thesis.hasSupervisorAccess(authenticatedUser)) {
+        if (!thesis.hasSupervisorAccess(currentUser)) {
             throw new AccessDeniedException("You need to be a supervisor of this thesis to add a final grade");
         }
 
@@ -719,23 +688,22 @@ public class ThesisController {
                 RequestValidator.validateNotNull(payload.visibility())
         );
 
-        return ResponseEntity.ok(ThesisDto.fromThesisEntity(thesis, thesis.hasAdvisorAccess(authenticatedUser), thesis.hasStudentAccess(authenticatedUser)));
+        return ResponseEntity.ok(ThesisDto.fromThesisEntity(thesis, thesis.hasAdvisorAccess(currentUser), thesis.hasStudentAccess(currentUser)));
     }
 
     @PostMapping("/{thesisId}/complete")
     public ResponseEntity<ThesisDto> completeThesis(
-            @PathVariable UUID thesisId,
-            JwtAuthenticationToken jwt
+            @PathVariable UUID thesisId
     ) {
-        User authenticatedUser = authenticationService.getAuthenticatedUser(jwt);
+        User currentUser = currentUserProvider().getUser();
         Thesis thesis = thesisService.findById(thesisId);
 
-        if (!thesis.hasSupervisorAccess(authenticatedUser)) {
+        if (!thesis.hasSupervisorAccess(currentUser)) {
             throw new AccessDeniedException("You need to be a supervisor of this thesis to close the thesis");
         }
 
         thesis = thesisService.completeThesis(thesis);
 
-        return ResponseEntity.ok(ThesisDto.fromThesisEntity(thesis, thesis.hasAdvisorAccess(authenticatedUser), thesis.hasStudentAccess(authenticatedUser)));
+        return ResponseEntity.ok(ThesisDto.fromThesisEntity(thesis, thesis.hasAdvisorAccess(currentUser), thesis.hasStudentAccess(currentUser)));
     }
 }

--- a/server/src/main/java/de/tum/cit/aet/thesis/controller/ThesisController.java
+++ b/server/src/main/java/de/tum/cit/aet/thesis/controller/ThesisController.java
@@ -54,6 +54,7 @@ public class ThesisController {
     @GetMapping
     public ResponseEntity<PaginationDto<ThesisDto>> getTheses(
             @RequestParam(required = false) String search,
+            @RequestParam(required = false, defaultValue = "true") boolean onlyOwnResearchGroup,
             @RequestParam(required = false) ThesisState[] state,
             @RequestParam(required = false) String[] type,
             @RequestParam(required = false, defaultValue = "false") boolean fetchAll,
@@ -87,6 +88,7 @@ public class ThesisController {
 
         Page<Thesis> theses = thesisService.getAll(
                 userId,
+                onlyOwnResearchGroup,
                 visibilities,
                 search,
                 state,

--- a/server/src/main/java/de/tum/cit/aet/thesis/controller/TopicController.java
+++ b/server/src/main/java/de/tum/cit/aet/thesis/controller/TopicController.java
@@ -5,7 +5,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Page;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
-import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationToken;
 import org.springframework.web.bind.annotation.*;
 import de.tum.cit.aet.thesis.constants.StringLimits;
 import de.tum.cit.aet.thesis.controller.payload.CloseTopicPayload;
@@ -13,9 +12,7 @@ import de.tum.cit.aet.thesis.controller.payload.ReplaceTopicPayload;
 import de.tum.cit.aet.thesis.dto.PaginationDto;
 import de.tum.cit.aet.thesis.dto.TopicDto;
 import de.tum.cit.aet.thesis.entity.Topic;
-import de.tum.cit.aet.thesis.entity.User;
 import de.tum.cit.aet.thesis.service.ApplicationService;
-import de.tum.cit.aet.thesis.service.AuthenticationService;
 import de.tum.cit.aet.thesis.service.TopicService;
 import de.tum.cit.aet.thesis.utility.RequestValidator;
 
@@ -26,13 +23,11 @@ import java.util.UUID;
 @RequestMapping("/v2/topics")
 public class TopicController {
     private final TopicService topicService;
-    private final AuthenticationService authenticationService;
     private final ApplicationService applicationService;
 
     @Autowired
-    public TopicController(TopicService topicService, AuthenticationService authenticationService, ApplicationService applicationService) {
+    public TopicController(TopicService topicService, ApplicationService applicationService) {
         this.topicService = topicService;
-        this.authenticationService = authenticationService;
         this.applicationService = applicationService;
     }
 
@@ -69,13 +64,9 @@ public class TopicController {
     @PostMapping
     @PreAuthorize("hasAnyRole('admin', 'advisor', 'supervisor')")
     public ResponseEntity<TopicDto> createTopic(
-            @RequestBody ReplaceTopicPayload payload,
-            JwtAuthenticationToken jwt
+            @RequestBody ReplaceTopicPayload payload
     ) {
-        User authenticatedUser = authenticationService.getAuthenticatedUser(jwt);
-
         Topic topic = topicService.createTopic(
-                authenticatedUser,
                 RequestValidator.validateStringMaxLength(payload.title(), StringLimits.THESIS_TITLE.getLimit()),
                 RequestValidator.validateStringSetItemMaxLengthAllowNull(payload.thesisTypes(), StringLimits.SHORTTEXT.getLimit()),
                 RequestValidator.validateStringMaxLength(payload.problemStatement(), StringLimits.UNLIMITED_TEXT.getLimit()),
@@ -93,14 +84,11 @@ public class TopicController {
     @PreAuthorize("hasAnyRole('admin', 'advisor', 'supervisor')")
     public ResponseEntity<TopicDto> updateTopic(
             @PathVariable UUID topicId,
-            @RequestBody ReplaceTopicPayload payload,
-            JwtAuthenticationToken jwt
+            @RequestBody ReplaceTopicPayload payload
     ) {
-        User authenticatedUser = authenticationService.getAuthenticatedUser(jwt);
         Topic topic = topicService.findById(topicId);
 
         topic = topicService.updateTopic(
-                authenticatedUser,
                 topic,
                 RequestValidator.validateStringMaxLength(payload.title(), StringLimits.THESIS_TITLE.getLimit()),
                 RequestValidator.validateStringSetItemMaxLengthAllowNull(payload.thesisTypes(), StringLimits.SHORTTEXT.getLimit()),
@@ -119,14 +107,11 @@ public class TopicController {
     @PreAuthorize("hasAnyRole('admin', 'advisor', 'supervisor')")
     public ResponseEntity<TopicDto> closeTopic(
             @PathVariable UUID topicId,
-            @RequestBody CloseTopicPayload payload,
-            JwtAuthenticationToken jwt
+            @RequestBody CloseTopicPayload payload
     ) {
-        User authenticatedUser = authenticationService.getAuthenticatedUser(jwt);
         Topic topic = topicService.findById(topicId);
 
         topic = applicationService.closeTopic(
-                authenticatedUser,
                 topic,
                 RequestValidator.validateNotNull(payload.reason()),
                 RequestValidator.validateNotNull(payload.notifyUser())

--- a/server/src/main/java/de/tum/cit/aet/thesis/controller/TopicController.java
+++ b/server/src/main/java/de/tum/cit/aet/thesis/controller/TopicController.java
@@ -34,6 +34,7 @@ public class TopicController {
     @GetMapping
     public ResponseEntity<PaginationDto<TopicDto>> getTopics(
             @RequestParam(required = false) String search,
+            @RequestParam(required = false, defaultValue = "true") boolean onlyOwnResearchGroup,
             @RequestParam(required = false, defaultValue = "") String[] type,
             @RequestParam(required = false, defaultValue = "false") Boolean includeClosed,
             @RequestParam(required = false, defaultValue = "0") Integer page,
@@ -42,6 +43,7 @@ public class TopicController {
             @RequestParam(required = false, defaultValue = "desc") String sortOrder
     ) {
         Page<Topic> topics = topicService.getAll(
+                onlyOwnResearchGroup,
                 type,
                 includeClosed,
                 search,

--- a/server/src/main/java/de/tum/cit/aet/thesis/controller/UserInfoController.java
+++ b/server/src/main/java/de/tum/cit/aet/thesis/controller/UserInfoController.java
@@ -30,14 +30,14 @@ public class UserInfoController {
         this.authenticationService = authenticationService;
     }
 
-    @PostMapping
+    @GetMapping
     public ResponseEntity<UserDto> getInfo(JwtAuthenticationToken jwt) {
         User user = this.authenticationService.updateAuthenticatedUser(jwt);
 
         return ResponseEntity.ok(UserDto.fromUserEntity(user));
     }
 
-    @RequestMapping(method = RequestMethod.PUT, consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    @PutMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public ResponseEntity<UserDto> updateInfo(
             @RequestPart("data") UpdateUserInformationPayload payload,
             @RequestPart(value = "examinationReport", required = false) MultipartFile examinationReport,

--- a/server/src/main/java/de/tum/cit/aet/thesis/controller/payload/CreateApplicationPayload.java
+++ b/server/src/main/java/de/tum/cit/aet/thesis/controller/payload/CreateApplicationPayload.java
@@ -4,10 +4,11 @@ import java.time.Instant;
 import java.util.UUID;
 
 public record CreateApplicationPayload (
-        UUID topicId,
-        String thesisTitle,
-        String thesisType,
-        Instant desiredStartDate,
-        String motivation
+    UUID topicId,
+    String thesisTitle,
+    String thesisType,
+    Instant desiredStartDate,
+    String motivation,
+    UUID researchGroupId
 ) {
 }

--- a/server/src/main/java/de/tum/cit/aet/thesis/cron/ApplicationReminder.java
+++ b/server/src/main/java/de/tum/cit/aet/thesis/cron/ApplicationReminder.java
@@ -28,7 +28,9 @@ public class ApplicationReminder {
     @Scheduled(cron = "0 0 10 * * WED")
     public void emailReminder() {
         for (User user : userRepository.getRoleMembers(Set.of("admin", "supervisor", "advisor"))) {
-            long unreviewedApplications = applicationRepository.countUnreviewedApplications(user.getId());
+            long unreviewedApplications =
+                applicationRepository.countUnreviewedApplications(user.getId(),
+                    user.getResearchGroup().getId());
 
             if (unreviewedApplications > 0) {
                 mailingService.sendApplicationReminderEmail(user, unreviewedApplications);

--- a/server/src/main/java/de/tum/cit/aet/thesis/dto/UserDto.java
+++ b/server/src/main/java/de/tum/cit/aet/thesis/dto/UserDto.java
@@ -25,6 +25,7 @@ public record UserDto (
         Instant updatedAt,
         Instant joinedAt,
         Set<String> groups,
+        String researchGroupName,
         boolean hasCv,
         boolean hasExaminationReport,
         boolean hasDegreeReport
@@ -40,7 +41,8 @@ public record UserDto (
                 user.getStudyDegree(), user.getStudyProgram(), user.getProjects(), user.getInterests(),
                 user.getSpecialSkills(), user.getCustomData(), user.getEnrolledAt(), user.getUpdatedAt(), user.getJoinedAt(),
                 user.getGroups() == null ? Collections.emptySet() : new HashSet<>(user.getGroups().stream().map(x -> x.getId().getGroup()).toList()),
-                user.getCvFilename() != null, user.getExaminationFilename() != null, user.getDegreeFilename() != null
+                user.getResearchGroup() == null ? "" : user.getResearchGroup().getName(),
+            user.getCvFilename() != null,user.getExaminationFilename() != null, user.getDegreeFilename() != null
         );
     }
 }

--- a/server/src/main/java/de/tum/cit/aet/thesis/entity/Application.java
+++ b/server/src/main/java/de/tum/cit/aet/thesis/entity/Application.java
@@ -90,7 +90,7 @@ public class Application {
   private List<ApplicationReviewer> reviewers = new ArrayList<>();
 
   public boolean hasReadAccess(User user) {
-    if (user.hasAnyGroup("admin", "advisor", "supervisor")) {
+    if (user.hasAnyGroup("admin", "advisor", "supervisor") ) {
       return true;
     }
 

--- a/server/src/main/java/de/tum/cit/aet/thesis/entity/ThesisComment.java
+++ b/server/src/main/java/de/tum/cit/aet/thesis/entity/ThesisComment.java
@@ -53,4 +53,8 @@ public class ThesisComment {
     public boolean hasManagementAccess(User user) {
         return user.hasAnyGroup("admin") || createdBy.getId().equals(user.getId());
     }
+
+    public ResearchGroup getResearchGroup() {
+        return thesis.getResearchGroup();
+    }
 }

--- a/server/src/main/java/de/tum/cit/aet/thesis/entity/ThesisFile.java
+++ b/server/src/main/java/de/tum/cit/aet/thesis/entity/ThesisFile.java
@@ -44,4 +44,7 @@ public class ThesisFile {
     @JoinColumn(name = "uploaded_by", nullable = false)
     private User uploadedBy;
 
+    public ResearchGroup getResearchGroup() {
+        return thesis.getResearchGroup();
+    }
 }

--- a/server/src/main/java/de/tum/cit/aet/thesis/entity/ThesisPresentation.java
+++ b/server/src/main/java/de/tum/cit/aet/thesis/entity/ThesisPresentation.java
@@ -78,4 +78,8 @@ public class ThesisPresentation {
     public boolean hasManagementAccess(User user) {
         return thesis.hasAdvisorAccess(user) || createdBy.getId().equals(user.getId());
     }
+
+    public ResearchGroup getResearchGroup() {
+        return thesis != null ? thesis.getResearchGroup() : null;
+    }
 }

--- a/server/src/main/java/de/tum/cit/aet/thesis/entity/ThesisProposal.java
+++ b/server/src/main/java/de/tum/cit/aet/thesis/entity/ThesisProposal.java
@@ -44,4 +44,8 @@ public class ThesisProposal {
     @ManyToOne(fetch = FetchType.LAZY, optional = false)
     @JoinColumn(name = "created_by", nullable = false)
     private User createdBy;
+
+    public ResearchGroup getResearchGroup() {
+        return thesis.getResearchGroup();
+    }
 }

--- a/server/src/main/java/de/tum/cit/aet/thesis/entity/User.java
+++ b/server/src/main/java/de/tum/cit/aet/thesis/entity/User.java
@@ -1,19 +1,33 @@
 package de.tum.cit.aet.thesis.entity;
 
 import jakarta.mail.internet.InternetAddress;
-import jakarta.persistence.*;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.Table;
 import jakarta.validation.constraints.NotNull;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
 import lombok.Getter;
 import lombok.Setter;
 import org.hibernate.annotations.CreationTimestamp;
 import org.hibernate.annotations.JdbcTypeCode;
 import org.hibernate.annotations.UpdateTimestamp;
 import org.hibernate.type.SqlTypes;
-
-import java.security.MessageDigest;
-import java.security.NoSuchAlgorithmException;
-import java.time.Instant;
-import java.util.*;
 
 @Getter
 @Setter
@@ -90,6 +104,10 @@ public class User {
     @NotNull
     @Column(name = "joined_at", nullable = false)
     private Instant joinedAt;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "research_group_id")
+    private ResearchGroup researchGroup;
 
     @OneToMany(mappedBy = "user", fetch = FetchType.EAGER)
     private Set<UserGroup> groups = new HashSet<>();

--- a/server/src/main/java/de/tum/cit/aet/thesis/repository/ApplicationRepository.java
+++ b/server/src/main/java/de/tum/cit/aet/thesis/repository/ApplicationRepository.java
@@ -19,7 +19,7 @@ import java.util.UUID;
 public interface ApplicationRepository extends JpaRepository<Application, UUID> {
     @Query(
             "SELECT DISTINCT a FROM Application a WHERE " +
-            "(:userId IS NULL OR a.user.id = :userId) AND " +
+            "(:userId IS NULL OR a.user.id = :userId) AND " + "(:researchGroupId IS NULL OR a.researchGroup.id = :researchGroupId) AND " +
             "(:states IS NULL OR a.state IN :states OR (:previousIds IS NOT NULL AND a.id IN :previousIds)) AND " +
             "(:reviewerId IS NULL OR NOT EXISTS (SELECT ar FROM ApplicationReviewer ar WHERE a.id = ar.application.id AND ar.user.id = :reviewerId AND ar.reason = 'NOT_INTERESTED') OR (:previousIds IS NOT NULL AND a.id IN :previousIds)) AND " +
             "(:includeSuggestedTopics = true OR a.topic IS NOT NULL) AND " +
@@ -31,6 +31,7 @@ public interface ApplicationRepository extends JpaRepository<Application, UUID> 
             "LOWER(a.user.universityId) LIKE %:searchQuery%)"
     )
     Page<Application> searchApplications(
+            @Param("researchGroupId") UUID researchGroupId,
             @Param("userId") UUID userId,
             @Param("reviewerId") UUID reviewerId,
             @Param("searchQuery") String searchQuery,

--- a/server/src/main/java/de/tum/cit/aet/thesis/repository/ApplicationRepository.java
+++ b/server/src/main/java/de/tum/cit/aet/thesis/repository/ApplicationRepository.java
@@ -44,15 +44,17 @@ public interface ApplicationRepository extends JpaRepository<Application, UUID> 
     );
 
     @Query(
-            "SELECT COUNT(DISTINCT a) FROM Application a " +
+        "SELECT COUNT(DISTINCT a) FROM Application a " +
             "LEFT JOIN Topic t ON (a.topic.id = t.id) " +
             "LEFT JOIN TopicRole r ON (t.id = r.topic.id) " +
-            "WHERE " +
-                    "(a.topic IS NULL OR :userId IS NULL OR r.user.id = :userId) AND " +
-                    "a.state = 'NOT_ASSESSED' AND " +
-                    "(:userId IS NULL OR NOT EXISTS(SELECT ar FROM ApplicationReviewer ar WHERE ar.application.id = a.id AND ar.user.id = :userId))"
+            "WHERE (a.researchGroup.id IS NULL OR a.researchGroup.id = :researchGroupId) AND " +
+            "(t.researchGroup.id IS NULL OR t.researchGroup.id = :researchGroupId) AND" +
+            "(a.topic IS NULL OR :userId IS NULL OR r.user.id = :userId) AND " +
+            "a.state = 'NOT_ASSESSED' AND " +
+            "(:userId IS NULL OR NOT EXISTS(SELECT ar FROM ApplicationReviewer ar WHERE ar.application.id = a.id AND ar.user.id = :userId))"
     )
-    long countUnreviewedApplications(@Param("userId") UUID userId);
+    long countUnreviewedApplications(@Param("userId") UUID userId,
+        @Param("researchGroupId") UUID researchGroupId);
 
     @Query(
             "SELECT EXISTS (" +

--- a/server/src/main/java/de/tum/cit/aet/thesis/repository/ThesisRepository.java
+++ b/server/src/main/java/de/tum/cit/aet/thesis/repository/ThesisRepository.java
@@ -18,8 +18,9 @@ import java.util.UUID;
 @Repository
 public interface ThesisRepository extends JpaRepository<Thesis, UUID> {
     @Query(
-            "SELECT DISTINCT t FROM Thesis t LEFT JOIN ThesisRole r ON (t.id = r.thesis.id) WHERE " +
+        "SELECT DISTINCT t FROM Thesis t LEFT JOIN ThesisRole r ON (t.id = r.thesis.id) WHERE " +
             "(:userId IS NULL OR r.user.id = :userId) AND " +
+            "(:researchGroupId IS NULL OR t.researchGroup.id = :researchGroupId) AND " +
             "(:visibilities IS NULL OR t.visibility IN :visibilities OR r.user.id = :userId) AND " +
             "(:states IS NULL OR t.state IN :states) AND " +
             "(:types IS NULL OR t.type IN :types) AND " +
@@ -30,6 +31,7 @@ public interface ThesisRepository extends JpaRepository<Thesis, UUID> {
             "LOWER(r.user.universityId) LIKE %:searchQuery%)"
     )
     Page<Thesis> searchTheses(
+            @Param("researchGroupId") UUID researchGroupId,
             @Param("userId") UUID userId,
             @Param("visibilities") Set<ThesisVisibility> visibilities,
             @Param("searchQuery") String searchQuery,

--- a/server/src/main/java/de/tum/cit/aet/thesis/repository/ThesisRepository.java
+++ b/server/src/main/java/de/tum/cit/aet/thesis/repository/ThesisRepository.java
@@ -39,14 +39,16 @@ public interface ThesisRepository extends JpaRepository<Thesis, UUID> {
     );
 
     @Query(
-            "SELECT DISTINCT t FROM Thesis t LEFT JOIN ThesisRole r ON (t.id = r.thesis.id) WHERE " +
-            "(t.state != 'FINISHED' AND t.state != 'DROPPED_OUT') AND " +
+        "SELECT DISTINCT t FROM Thesis t LEFT JOIN ThesisRole r ON (t.id = r.thesis.id) WHERE " +
             "(:userId IS NULL OR r.user.id = :userId) AND " +
+            "(:researchGroupId IS NULL OR t.researchGroup.id = :researchGroupId) AND " +
+            "(t.state != 'FINISHED' AND t.state != 'DROPPED_OUT') AND " +
             "(:roleNames IS NULL OR r.id.role IN :roleNames) AND " +
             "(:states IS NULL OR t.state IN :states)"
     )
     List<Thesis> findActiveThesesForRole(
             @Param("userId") UUID userId,
+            @Param("researchGroupId") UUID researchGroupId,
             @Param("roleNames") Set<ThesisRoleName> roleNames,
             @Param("states") Set<ThesisState> states
     );

--- a/server/src/main/java/de/tum/cit/aet/thesis/repository/TopicRepository.java
+++ b/server/src/main/java/de/tum/cit/aet/thesis/repository/TopicRepository.java
@@ -26,6 +26,7 @@ public interface TopicRepository  extends JpaRepository<Topic, UUID>  {
             Pageable page
     );
 
-    @Query("SELECT COUNT(*) FROM Topic t WHERE t.closedAt IS NULL")
-    long countOpenTopics();
+    @Query("SELECT COUNT(*) FROM Topic t WHERE t.closedAt IS NULL AND (:researchGroupId IS NULL "
+        + "OR t.researchGroup.id = :researchGroupId)")
+    long countOpenTopics(@Param("researchGroupId") UUID researchGroupId);
 }

--- a/server/src/main/java/de/tum/cit/aet/thesis/repository/TopicRepository.java
+++ b/server/src/main/java/de/tum/cit/aet/thesis/repository/TopicRepository.java
@@ -13,13 +13,14 @@ import java.util.UUID;
 @Repository
 public interface TopicRepository  extends JpaRepository<Topic, UUID>  {
     @Query(value =
-            "SELECT t.* FROM topics t WHERE " +
+            "SELECT t.* FROM topics t WHERE (:researchGroupId IS NULL OR t.researchGroup.id = :researchGroupId) AND " +
             "(:searchQuery IS NULL OR t.title ILIKE CONCAT('%', :searchQuery, '%')) AND " +
             "(t.thesis_types IS NULL OR CAST(:types AS TEXT[]) IS NULL OR t.thesis_types && CAST(:types AS TEXT[])) AND " +
             "(:includeClosed = TRUE OR t.closed_at IS NULL)",
             nativeQuery = true
     )
     Page<Topic> searchTopics(
+            @Param("researchGroupId") UUID researchGroupId,
             @Param("types") String[] types,
             @Param("includeClosed") boolean includeClosed,
             @Param("searchQuery") String searchQuery,

--- a/server/src/main/java/de/tum/cit/aet/thesis/repository/TopicRepository.java
+++ b/server/src/main/java/de/tum/cit/aet/thesis/repository/TopicRepository.java
@@ -13,7 +13,7 @@ import java.util.UUID;
 @Repository
 public interface TopicRepository  extends JpaRepository<Topic, UUID>  {
     @Query(value =
-            "SELECT t.* FROM topics t WHERE (:researchGroupId IS NULL OR t.researchGroup.id = :researchGroupId) AND " +
+            "SELECT t.* FROM topics t WHERE (:researchGroupId IS NULL OR t.research_group_id = :researchGroupId) AND " +
             "(:searchQuery IS NULL OR t.title ILIKE CONCAT('%', :searchQuery, '%')) AND " +
             "(t.thesis_types IS NULL OR CAST(:types AS TEXT[]) IS NULL OR t.thesis_types && CAST(:types AS TEXT[])) AND " +
             "(:includeClosed = TRUE OR t.closed_at IS NULL)",

--- a/server/src/main/java/de/tum/cit/aet/thesis/repository/UserRepository.java
+++ b/server/src/main/java/de/tum/cit/aet/thesis/repository/UserRepository.java
@@ -22,7 +22,7 @@ public interface UserRepository extends JpaRepository<User, UUID> {
 
     @Query(
         "SELECT DISTINCT u FROM User u LEFT JOIN UserGroup g ON (u.id = g.id.userId) WHERE " +
-            "(:researchGroupId IS NULL OR t.researchGroup.id = :researchGroupId) AND " +
+            "(:researchGroupId IS NULL OR u.researchGroup.id = :researchGroupId) AND " +
             "(:groups IS NULL OR g.id.group IN :groups) AND " +
             "(:searchQuery IS NULL OR LOWER(u.firstName) || ' ' || LOWER(u.lastName) LIKE %:searchQuery% OR " +
             "LOWER(u.email) LIKE %:searchQuery% OR " +

--- a/server/src/main/java/de/tum/cit/aet/thesis/repository/UserRepository.java
+++ b/server/src/main/java/de/tum/cit/aet/thesis/repository/UserRepository.java
@@ -17,6 +17,9 @@ import java.util.UUID;
 public interface UserRepository extends JpaRepository<User, UUID> {
     Optional<User> findByUniversityId(String universityId);
 
+    @Query("SELECT u FROM User u LEFT JOIN FETCH u.researchGroup WHERE u.universityId = :universityId")
+    Optional<User> findByUniversityIdWithResearchGroup(@Param("universityId") String universityId);
+
     @Query(
             "SELECT DISTINCT u FROM User u LEFT JOIN UserGroup g ON (u.id = g.id.userId) WHERE " +
             "(:groups IS NULL OR g.id.group IN :groups) AND " +

--- a/server/src/main/java/de/tum/cit/aet/thesis/repository/UserRepository.java
+++ b/server/src/main/java/de/tum/cit/aet/thesis/repository/UserRepository.java
@@ -30,6 +30,9 @@ public interface UserRepository extends JpaRepository<User, UUID> {
     )
     Page<User> searchUsers(@Param("searchQuery") String searchQuery, @Param("groups") Set<String> groups, Pageable page);
 
-    @Query("SELECT DISTINCT u FROM User u LEFT JOIN UserGroup g ON (u.id = g.id.userId) WHERE g.id.group IN :roles")
-    List<User> getRoleMembers(@Param("roles") Set<String> roles);
+    @Query("SELECT DISTINCT u FROM User u LEFT JOIN UserGroup g ON (u.id = g.id.userId) WHERE g"
+        + ".id.group IN :roles AND (:researchGroupId IS NULL OR u.researchGroup.id = "
+        + ":researchGroupId)")
+    List<User> getRoleMembers(@Param("roles") Set<String> roles,
+        @Param("researchGroupId") UUID researchGroupId);
 }

--- a/server/src/main/java/de/tum/cit/aet/thesis/repository/UserRepository.java
+++ b/server/src/main/java/de/tum/cit/aet/thesis/repository/UserRepository.java
@@ -21,14 +21,16 @@ public interface UserRepository extends JpaRepository<User, UUID> {
     Optional<User> findByUniversityIdWithResearchGroup(@Param("universityId") String universityId);
 
     @Query(
-            "SELECT DISTINCT u FROM User u LEFT JOIN UserGroup g ON (u.id = g.id.userId) WHERE " +
+        "SELECT DISTINCT u FROM User u LEFT JOIN UserGroup g ON (u.id = g.id.userId) WHERE " +
+            "(:researchGroupId IS NULL OR t.researchGroup.id = :researchGroupId) AND " +
             "(:groups IS NULL OR g.id.group IN :groups) AND " +
             "(:searchQuery IS NULL OR LOWER(u.firstName) || ' ' || LOWER(u.lastName) LIKE %:searchQuery% OR " +
             "LOWER(u.email) LIKE %:searchQuery% OR " +
             "LOWER(u.matriculationNumber) LIKE %:searchQuery% OR " +
             "LOWER(u.universityId) LIKE %:searchQuery%)"
     )
-    Page<User> searchUsers(@Param("searchQuery") String searchQuery, @Param("groups") Set<String> groups, Pageable page);
+    Page<User> searchUsers(@Param("researchGroupId") UUID researchGroupId,
+        @Param("searchQuery") String searchQuery, @Param("groups") Set<String> groups, Pageable page);
 
     @Query("SELECT DISTINCT u FROM User u LEFT JOIN UserGroup g ON (u.id = g.id.userId) WHERE g"
         + ".id.group IN :roles AND (:researchGroupId IS NULL OR u.researchGroup.id = "

--- a/server/src/main/java/de/tum/cit/aet/thesis/security/CurrentUserProvider.java
+++ b/server/src/main/java/de/tum/cit/aet/thesis/security/CurrentUserProvider.java
@@ -59,7 +59,7 @@ public class CurrentUserProvider {
    }
 
    public boolean canSeeAllResearchGroups() {
-      return isStudent();
+      return isStudent() || isAdmin();
    }
 
    public void assertSameResearchGroupIfNotPrivileged(ResearchGroup target) {

--- a/server/src/main/java/de/tum/cit/aet/thesis/security/CurrentUserProvider.java
+++ b/server/src/main/java/de/tum/cit/aet/thesis/security/CurrentUserProvider.java
@@ -1,0 +1,90 @@
+package de.tum.cit.aet.thesis.security;
+
+import de.tum.cit.aet.thesis.entity.ResearchGroup;
+import de.tum.cit.aet.thesis.entity.User;
+import de.tum.cit.aet.thesis.exception.request.AccessDeniedException;
+import de.tum.cit.aet.thesis.service.AuthenticationService;
+import jakarta.annotation.PostConstruct;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Scope;
+import org.springframework.context.annotation.ScopedProxyMode;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationToken;
+import org.springframework.stereotype.Component;
+import org.springframework.web.context.WebApplicationContext;
+
+@Component
+@Scope(value = WebApplicationContext.SCOPE_REQUEST, proxyMode = ScopedProxyMode.TARGET_CLASS)
+@RequiredArgsConstructor
+public class CurrentUserProvider {
+
+   private final AuthenticationService authenticationService;
+   private User cachedUser;
+
+   @PostConstruct
+   public void loadUser() {
+      JwtAuthenticationToken jwt = (JwtAuthenticationToken) SecurityContextHolder.getContext().getAuthentication();
+      cachedUser = authenticationService.getAuthenticatedUserWithResearchGroup(jwt);
+   }
+
+   public User getUser() {
+      return cachedUser;
+   }
+
+   public ResearchGroup getResearchGroupOrThrow() {
+      ResearchGroup researchGroup = cachedUser.getResearchGroup();
+      if (!canSeeAllResearchGroups() && researchGroup == null) {
+         throw new AccessDeniedException("Your account must be assigned to a research group.");
+      }
+      return researchGroup;
+   }
+
+   public boolean isStudent() {
+      return cachedUser.hasAnyGroup("student");
+   }
+   
+   public boolean isAdvisor() {
+      return cachedUser.hasAnyGroup("advisor");
+   }
+   
+   public boolean isSupervisor() {
+      return cachedUser.hasAnyGroup("supervisor");
+   }
+   
+   public boolean isAdmin() {
+      return cachedUser.hasAnyGroup("admin");
+   }
+
+   public boolean canSeeAllResearchGroups() {
+      return isStudent();
+   }
+
+   public void assertSameResearchGroupIfNotPrivileged(ResearchGroup target) {
+      if (!canSeeAllResearchGroups()) {
+         assertCanAccessResearchGroup(target);
+      }
+   }
+   
+   public void assertCanAccessResearchGroup(ResearchGroup target) {
+      if (canSeeAllResearchGroups()) {
+         return;
+      }
+
+      ResearchGroup own = getResearchGroupOrThrow();
+      if (target == null || !own.getId().equals(target.getId())) {
+         throw new AccessDeniedException("This resource is not part of your research group.");
+      }
+   }
+   
+   public void assertCanAccessResearchGroup(UUID target) {
+      if (canSeeAllResearchGroups()) {
+         return;
+      }
+
+      ResearchGroup own = getResearchGroupOrThrow();
+      if (!own.getId().equals(target)) {
+         throw new AccessDeniedException("This resource is not part of your research group.");
+      }
+   }
+}

--- a/server/src/main/java/de/tum/cit/aet/thesis/security/CurrentUserProvider.java
+++ b/server/src/main/java/de/tum/cit/aet/thesis/security/CurrentUserProvider.java
@@ -9,6 +9,7 @@ import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Scope;
 import org.springframework.context.annotation.ScopedProxyMode;
+import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationToken;
 import org.springframework.stereotype.Component;
@@ -24,8 +25,13 @@ public class CurrentUserProvider {
 
    @PostConstruct
    public void loadUser() {
-      JwtAuthenticationToken jwt = (JwtAuthenticationToken) SecurityContextHolder.getContext().getAuthentication();
-      cachedUser = authenticationService.getAuthenticatedUserWithResearchGroup(jwt);
+      Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+      if (authentication instanceof JwtAuthenticationToken) {
+         JwtAuthenticationToken jwt = (JwtAuthenticationToken) authentication;
+         cachedUser = authenticationService.getAuthenticatedUserWithResearchGroup(jwt);
+      } else {
+         throw new AccessDeniedException("Please login first.");
+      }
    }
 
    public User getUser() {

--- a/server/src/main/java/de/tum/cit/aet/thesis/security/WebSecurityConfig.java
+++ b/server/src/main/java/de/tum/cit/aet/thesis/security/WebSecurityConfig.java
@@ -6,7 +6,6 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Profile;
 import org.springframework.http.HttpMethod;
-import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
@@ -17,8 +16,6 @@ import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.session.RegisterSessionAuthenticationStrategy;
 import org.springframework.security.web.authentication.session.SessionAuthenticationStrategy;
 import org.springframework.web.cors.CorsConfigurationSource;
-import org.springframework.web.servlet.config.annotation.CorsRegistry;
-import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
 @Configuration
 @EnableWebSecurity

--- a/server/src/main/java/de/tum/cit/aet/thesis/service/ApplicationService.java
+++ b/server/src/main/java/de/tum/cit/aet/thesis/service/ApplicationService.java
@@ -25,7 +25,6 @@ import java.util.*;
 @Service
 public class ApplicationService {
     private final ApplicationRepository applicationRepository;
-    private final ApplicationService self;
     private final MailingService mailingService;
     private final TopicRepository topicRepository;
     private final ThesisService thesisService;
@@ -36,7 +35,6 @@ public class ApplicationService {
     @Autowired
     public ApplicationService(
             ApplicationRepository applicationRepository,
-            ApplicationService self,
             MailingService mailingService,
             TopicRepository topicRepository,
             ThesisService thesisService,
@@ -45,7 +43,6 @@ public class ApplicationService {
             ObjectProvider<CurrentUserProvider> currentUserProviderProvider
     ) {
         this.applicationRepository = applicationRepository;
-        this.self = self;
         this.mailingService = mailingService;
         this.topicRepository = topicRepository;
         this.thesisService = thesisService;
@@ -154,7 +151,7 @@ public class ApplicationService {
         application.setState(ApplicationState.ACCEPTED);
         application.setReviewedAt(Instant.now());
 
-        application = self.reviewApplication(application, reviewingUser,
+        application = reviewApplication(application, reviewingUser,
             ApplicationReviewReason.INTERESTED);
 
         Thesis thesis = thesisService.createThesis(
@@ -175,7 +172,7 @@ public class ApplicationService {
         if (topic != null && closeTopic) {
             topic.setClosedAt(Instant.now());
 
-            result.addAll(self.rejectApplicationsForTopic(reviewingUser, topic,
+            result.addAll(rejectApplicationsForTopic(reviewingUser, topic,
                 ApplicationRejectReason.TOPIC_FILLED, true));
 
             application.setTopic(topicRepository.save(topic));
@@ -197,7 +194,7 @@ public class ApplicationService {
         application.setRejectReason(reason);
         application.setReviewedAt(Instant.now());
 
-        application = self.reviewApplication(application, reviewingUser,
+        application = reviewApplication(application, reviewingUser,
             ApplicationReviewReason.NOT_INTERESTED);
 
         List<Application> result = new ArrayList<>();
@@ -211,7 +208,7 @@ public class ApplicationService {
                     item.setRejectReason(reason);
                     item.setReviewedAt(Instant.now());
 
-                    item = self.reviewApplication(item, reviewingUser,
+                    item = reviewApplication(item, reviewingUser,
                         ApplicationReviewReason.NOT_INTERESTED);
 
                     result.add(applicationRepository.save(item));
@@ -233,7 +230,7 @@ public class ApplicationService {
         currentUserProvider().assertCanAccessResearchGroup(topic.getResearchGroup());
         topic.setClosedAt(Instant.now());
 
-        self.rejectApplicationsForTopic(currentUserProvider().getUser(), topic, reason, notifyUser);
+        rejectApplicationsForTopic(currentUserProvider().getUser(), topic, reason, notifyUser);
 
         return topicRepository.save(topic);
     }
@@ -249,7 +246,7 @@ public class ApplicationService {
                 continue;
             }
 
-            result.addAll(self.reject(closer, application, reason, notifyUser));
+            result.addAll(reject(closer, application, reason, notifyUser));
         }
 
         return result;

--- a/server/src/main/java/de/tum/cit/aet/thesis/service/ApplicationService.java
+++ b/server/src/main/java/de/tum/cit/aet/thesis/service/ApplicationService.java
@@ -81,7 +81,8 @@ public class ApplicationService {
     }
 
     @Transactional
-    public Application createApplication(User user, UUID topicId, String thesisTitle, String thesisType, Instant desiredStartDate, String motivation) {
+    public Application createApplication(User user, UUID topicId, String thesisTitle,
+        String thesisType, Instant desiredStartDate, String motivation, ResearchGroup researchGroup) {
         Topic topic = topicId == null ? null : topicService.findById(topicId);
 
         if (topic != null && topic.getClosedAt() != null) {
@@ -99,6 +100,7 @@ public class ApplicationService {
         application.setState(ApplicationState.NOT_ASSESSED);
         application.setDesiredStartDate(desiredStartDate);
         application.setCreatedAt(Instant.now());
+        application.setResearchGroup(researchGroup);
 
         application = applicationRepository.save(application);
 

--- a/server/src/main/java/de/tum/cit/aet/thesis/service/ApplicationService.java
+++ b/server/src/main/java/de/tum/cit/aet/thesis/service/ApplicationService.java
@@ -229,11 +229,11 @@ public class ApplicationService {
     }
 
     @Transactional
-    public Topic closeTopic(User closer, Topic topic, ApplicationRejectReason reason, boolean notifyUser) {
+    public Topic closeTopic(Topic topic, ApplicationRejectReason reason, boolean notifyUser) {
         currentUserProvider().assertCanAccessResearchGroup(topic.getResearchGroup());
         topic.setClosedAt(Instant.now());
 
-        self.rejectApplicationsForTopic(closer, topic, reason, notifyUser);
+        self.rejectApplicationsForTopic(currentUserProvider().getUser(), topic, reason, notifyUser);
 
         return topicRepository.save(topic);
     }

--- a/server/src/main/java/de/tum/cit/aet/thesis/service/AuthenticationService.java
+++ b/server/src/main/java/de/tum/cit/aet/thesis/service/AuthenticationService.java
@@ -39,6 +39,11 @@ public class AuthenticationService {
                 .orElseThrow(() -> new ResourceNotFoundException("Authenticated user not found"));
     }
 
+    public User getAuthenticatedUserWithResearchGroup(JwtAuthenticationToken jwt) {
+        return userRepository.findByUniversityIdWithResearchGroup(getUniversityId(jwt))
+                .orElseThrow(() -> new ResourceNotFoundException("Authenticated user not found"));
+    }
+
     @Transactional
     public User updateAuthenticatedUser(JwtAuthenticationToken jwt) {
         Map<String, Object> attributes = jwt.getTokenAttributes();

--- a/server/src/main/java/de/tum/cit/aet/thesis/service/ResearchGroupService.java
+++ b/server/src/main/java/de/tum/cit/aet/thesis/service/ResearchGroupService.java
@@ -11,6 +11,7 @@ import java.util.UUID;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -52,12 +53,16 @@ public class ResearchGroupService {
     String[] headsFilter = heads == null || heads.length == 0 ? null : heads;
     String[] campusesFilter = campuses == null || campuses.length == 0 ? null : campuses;
 
+    Pageable pageable = limit == -1
+        ? PageRequest.of(0, Integer.MAX_VALUE, Sort.by(order))
+        : PageRequest.of(page, limit, Sort.by(order));
+
     return researchGroupRepository.searchResearchGroup(
         headsFilter,
         campusesFilter,
         includeArchived,
         searchQueryFilter,
-        PageRequest.of(page, limit, Sort.by(order))
+        pageable
     );
   }
 

--- a/server/src/main/java/de/tum/cit/aet/thesis/service/ThesisService.java
+++ b/server/src/main/java/de/tum/cit/aet/thesis/service/ThesisService.java
@@ -56,7 +56,8 @@ public class ThesisService {
             AccessManagementService accessManagementService,
             ThesisPresentationService thesisPresentationService,
             ThesisFeedbackRepository thesisFeedbackRepository, ThesisFileRepository thesisFileRepository,
-            ObjectProvider<CurrentUserProvider> currentUserProviderProvider) {
+            ObjectProvider<CurrentUserProvider> currentUserProviderProvider
+    ) {
         this.thesisRoleRepository = thesisRoleRepository;
         this.thesisRepository = thesisRepository;
         this.thesisStateChangeRepository = thesisStateChangeRepository;
@@ -69,7 +70,7 @@ public class ThesisService {
         this.thesisPresentationService = thesisPresentationService;
         this.thesisFeedbackRepository = thesisFeedbackRepository;
         this.thesisFileRepository = thesisFileRepository;
-       this.currentUserProviderProvider = currentUserProviderProvider;
+        this.currentUserProviderProvider = currentUserProviderProvider;
     }
 
     private CurrentUserProvider currentUserProvider() {
@@ -77,31 +78,33 @@ public class ThesisService {
     }
 
     public Page<Thesis> getAll(
-            UUID userId,
-            Set<ThesisVisibility> visibilities,
-            String searchQuery,
-            ThesisState[] states,
-            String[] types,
-            int page,
-            int limit,
-            String sortBy,
-            String sortOrder
+        UUID userId,
+        boolean onlyOwnResearchGroup,
+        Set<ThesisVisibility> visibilities,
+        String searchQuery,
+        ThesisState[] states,
+        String[] types,
+        int page,
+        int limit,
+        String sortBy,
+        String sortOrder
     ) {
         Sort.Order order = new Sort.Order(sortOrder.equals("asc") ? Sort.Direction.ASC : Sort.Direction.DESC, sortBy);
 
-        ResearchGroup researchGroup = currentUserProvider().getResearchGroupOrThrow();
+        ResearchGroup researchGroup = onlyOwnResearchGroup ?
+            currentUserProvider().getResearchGroupOrThrow() : null;
         String searchQueryFilter = searchQuery == null || searchQuery.isEmpty() ? null : searchQuery.toLowerCase();
         Set<ThesisState> statesFilter = states == null || states.length == 0 ? null : new HashSet<>(Arrays.asList(states));
         Set<String> typesFilter = types == null || types.length == 0 ? null : new HashSet<>(Arrays.asList(types));
 
         return thesisRepository.searchTheses(
-                researchGroup == null ? null : researchGroup.getId(),
-                userId,
-                visibilities,
-                searchQueryFilter,
-                statesFilter,
-                typesFilter,
-                PageRequest.of(page, limit, Sort.by(order))
+            researchGroup == null ? null : researchGroup.getId(),
+            userId,
+            visibilities,
+            searchQueryFilter,
+            statesFilter,
+            typesFilter,
+            PageRequest.of(page, limit, Sort.by(order))
         );
     }
 

--- a/server/src/main/java/de/tum/cit/aet/thesis/service/ThesisService.java
+++ b/server/src/main/java/de/tum/cit/aet/thesis/service/ThesisService.java
@@ -1,5 +1,7 @@
 package de.tum.cit.aet.thesis.service;
 
+import de.tum.cit.aet.thesis.security.CurrentUserProvider;
+import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.io.Resource;
 import org.springframework.data.domain.Page;
@@ -39,6 +41,7 @@ public class ThesisService {
     private final ThesisPresentationService thesisPresentationService;
     private final ThesisFeedbackRepository thesisFeedbackRepository;
     private final ThesisFileRepository thesisFileRepository;
+    private final ObjectProvider<CurrentUserProvider> currentUserProviderProvider;
 
     @Autowired
     public ThesisService(
@@ -52,7 +55,8 @@ public class ThesisService {
             MailingService mailingService,
             AccessManagementService accessManagementService,
             ThesisPresentationService thesisPresentationService,
-            ThesisFeedbackRepository thesisFeedbackRepository, ThesisFileRepository thesisFileRepository) {
+            ThesisFeedbackRepository thesisFeedbackRepository, ThesisFileRepository thesisFileRepository,
+            ObjectProvider<CurrentUserProvider> currentUserProviderProvider) {
         this.thesisRoleRepository = thesisRoleRepository;
         this.thesisRepository = thesisRepository;
         this.thesisStateChangeRepository = thesisStateChangeRepository;
@@ -65,6 +69,11 @@ public class ThesisService {
         this.thesisPresentationService = thesisPresentationService;
         this.thesisFeedbackRepository = thesisFeedbackRepository;
         this.thesisFileRepository = thesisFileRepository;
+       this.currentUserProviderProvider = currentUserProviderProvider;
+    }
+
+    private CurrentUserProvider currentUserProvider() {
+        return currentUserProviderProvider.getObject();
     }
 
     public Page<Thesis> getAll(
@@ -80,11 +89,13 @@ public class ThesisService {
     ) {
         Sort.Order order = new Sort.Order(sortOrder.equals("asc") ? Sort.Direction.ASC : Sort.Direction.DESC, sortBy);
 
+        ResearchGroup researchGroup = currentUserProvider().getResearchGroupOrThrow();
         String searchQueryFilter = searchQuery == null || searchQuery.isEmpty() ? null : searchQuery.toLowerCase();
         Set<ThesisState> statesFilter = states == null || states.length == 0 ? null : new HashSet<>(Arrays.asList(states));
         Set<String> typesFilter = types == null || types.length == 0 ? null : new HashSet<>(Arrays.asList(types));
 
         return thesisRepository.searchTheses(
+                researchGroup == null ? null : researchGroup.getId(),
                 userId,
                 visibilities,
                 searchQueryFilter,
@@ -96,7 +107,6 @@ public class ThesisService {
 
     @Transactional
     public Thesis createThesis(
-            User creator,
             String thesisTitle,
             String thesisType,
             String language,
@@ -119,14 +129,15 @@ public class ThesisService {
         thesis.setState(ThesisState.PROPOSAL);
         thesis.setApplication(application);
         thesis.setCreatedAt(Instant.now());
+        thesis.setResearchGroup(currentUserProvider().getResearchGroupOrThrow());
 
         thesis = thesisRepository.save(thesis);
 
-        assignThesisRoles(thesis, creator, supervisorIds, advisorIds, studentIds);
-        saveStateChange(thesis, ThesisState.PROPOSAL, Instant.now());
+        assignThesisRoles(thesis, supervisorIds, advisorIds, studentIds);
+        saveStateChange(thesis, ThesisState.PROPOSAL);
 
         if (notifyUser) {
-            mailingService.sendThesisCreatedEmail(creator, thesis);
+            mailingService.sendThesisCreatedEmail(currentUserProvider().getUser(), thesis);
         }
 
         for (User student : thesis.getStudents()) {
@@ -137,17 +148,18 @@ public class ThesisService {
     }
 
     @Transactional
-    public Thesis closeThesis(User closingUser, Thesis thesis) {
+    public Thesis closeThesis(Thesis thesis) {
+        currentUserProvider().assertCanAccessResearchGroup(thesis.getResearchGroup());
         if (thesis.getState() == ThesisState.DROPPED_OUT || thesis.getState() == ThesisState.FINISHED) {
             throw new ResourceInvalidParametersException("Thesis is already completed");
         }
 
         thesis.setState(ThesisState.DROPPED_OUT);
-        saveStateChange(thesis, ThesisState.DROPPED_OUT, Instant.now());
+        saveStateChange(thesis, ThesisState.DROPPED_OUT);
 
         thesis = thesisRepository.save(thesis);
 
-        mailingService.sendThesisClosedEmail(closingUser, thesis);
+        mailingService.sendThesisClosedEmail(currentUserProvider().getUser(), thesis);
 
         for (User student : thesis.getStudents()) {
             if (!existsPendingThesis(student)) {
@@ -160,7 +172,6 @@ public class ThesisService {
 
     @Transactional
     public Thesis updateThesis(
-            User updatingUser,
             Thesis thesis,
             String thesisTitle,
             String thesisType,
@@ -174,6 +185,7 @@ public class ThesisService {
             List<UUID> supervisorIds,
             List<ThesisStatePayload> states
     ) {
+        currentUserProvider().assertCanAccessResearchGroup(thesis.getResearchGroup());
         thesis.setTitle(thesisTitle);
         thesis.setType(thesisType);
         thesis.setLanguage(language);
@@ -187,10 +199,10 @@ public class ThesisService {
         thesis.setStartDate(startDate);
         thesis.setEndDate(endDate);
 
-        assignThesisRoles(thesis, updatingUser, supervisorIds, advisorIds, studentIds);
+        assignThesisRoles(thesis, supervisorIds, advisorIds, studentIds);
 
         for (ThesisStatePayload state : states) {
-            saveStateChange(thesis, state.state(), state.changedAt());
+            saveStateChange(thesis, state.state());
         }
 
         thesis = thesisRepository.save(thesis);
@@ -206,6 +218,7 @@ public class ThesisService {
             String abstractText,
             String infoText
     ) {
+        currentUserProvider().assertCanAccessResearchGroup(thesis.getResearchGroup());
         thesis.setAbstractField(abstractText);
         thesis.setInfo(infoText);
 
@@ -222,6 +235,7 @@ public class ThesisService {
             String primaryTitle,
             Map<String, String> titles
     ) {
+        currentUserProvider().assertCanAccessResearchGroup(thesis.getResearchGroup());
         thesis.setMetadata(new ThesisMetadata(
                 titles,
                 thesis.getMetadata().credits()
@@ -240,6 +254,7 @@ public class ThesisService {
             Thesis thesis,
             Map<UUID, Number> credits
     ) {
+        currentUserProvider().assertCanAccessResearchGroup(thesis.getResearchGroup());
         thesis.setMetadata(new ThesisMetadata(
                 thesis.getMetadata().titles(),
                 credits
@@ -250,6 +265,7 @@ public class ThesisService {
 
     /* FEEDBACK */
     public Thesis completeFeedback(Thesis thesis, UUID feedbackId, boolean completed) {
+        currentUserProvider().assertCanAccessResearchGroup(thesis.getResearchGroup());
         ThesisFeedback feedback = thesis.getFeedbackItem(feedbackId)
                 .orElseThrow(() -> new ResourceNotFoundException("Feedback id not found"));
 
@@ -262,6 +278,7 @@ public class ThesisService {
 
     @Transactional
     public Thesis deleteFeedback(Thesis thesis, UUID feedbackId) {
+        currentUserProvider().assertCanAccessResearchGroup(thesis.getResearchGroup());
         thesis.getFeedbackItem(feedbackId)
                 .orElseThrow(() -> new ResourceNotFoundException("Feedback id not found"));
 
@@ -275,12 +292,13 @@ public class ThesisService {
     }
 
     @Transactional
-    public Thesis requestChanges(User authenticatedUser, Thesis thesis, ThesisFeedbackType type, List<RequestChangesPayload.RequestedChange> requestedChanges) {
+    public Thesis requestChanges(Thesis thesis, ThesisFeedbackType type, List<RequestChangesPayload.RequestedChange> requestedChanges) {
+        currentUserProvider().assertCanAccessResearchGroup(thesis.getResearchGroup());
         for (var requestedChange : requestedChanges) {
             ThesisFeedback feedback = new ThesisFeedback();
 
             feedback.setRequestedAt(Instant.now());
-            feedback.setRequestedBy(authenticatedUser);
+            feedback.setRequestedBy(currentUserProvider().getUser());
             feedback.setThesis(thesis);
             feedback.setType(type);
             feedback.setFeedback(RequestValidator.validateStringMaxLength(requestedChange.feedback(), StringLimits.LONGTEXT.getLimit()));
@@ -293,7 +311,7 @@ public class ThesisService {
         }
 
         if (type == ThesisFeedbackType.PROPOSAL) {
-            mailingService.sendProposalChangeRequestEmail(authenticatedUser, thesis);
+            mailingService.sendProposalChangeRequestEmail(currentUserProvider().getUser(), thesis);
         }
 
         return thesis;
@@ -302,17 +320,19 @@ public class ThesisService {
     /* PROPOSAL */
 
     public Resource getProposalFile(ThesisProposal proposal) {
+        currentUserProvider().assertCanAccessResearchGroup(proposal.getResearchGroup());
         return uploadService.load(proposal.getProposalFilename());
     }
 
     @Transactional
-    public Thesis uploadProposal(User uploadingUser, Thesis thesis, MultipartFile proposalFile) {
+    public Thesis uploadProposal(Thesis thesis, MultipartFile proposalFile) {
+        currentUserProvider().assertCanAccessResearchGroup(thesis.getResearchGroup());
         ThesisProposal proposal = new ThesisProposal();
 
         proposal.setThesis(thesis);
         proposal.setProposalFilename(uploadService.store(proposalFile, 20 * 1024 * 1024, UploadFileType.PDF));
         proposal.setCreatedAt(Instant.now());
-        proposal.setCreatedBy(uploadingUser);
+        proposal.setCreatedBy(currentUserProvider().getUser());
 
         List<ThesisProposal> proposals = thesis.getProposals() == null ? new ArrayList<>() : thesis.getProposals();
         proposals.addFirst(proposal);
@@ -328,6 +348,7 @@ public class ThesisService {
 
     @Transactional
     public Thesis deleteProposal(Thesis thesis, UUID proposalId) {
+        currentUserProvider().assertCanAccessResearchGroup(thesis.getResearchGroup());
         thesis.getProposalById(proposalId)
                 .orElseThrow(() -> new ResourceNotFoundException("Proposal id not found"));
 
@@ -341,7 +362,8 @@ public class ThesisService {
     }
 
     @Transactional
-    public Thesis acceptProposal(User reviewingUser, Thesis thesis) {
+    public Thesis acceptProposal(Thesis thesis) {
+        currentUserProvider().assertCanAccessResearchGroup(thesis.getResearchGroup());
         List<ThesisProposal> proposals = thesis.getProposals();
 
         if (proposals == null || proposals.isEmpty()) {
@@ -351,11 +373,11 @@ public class ThesisService {
         ThesisProposal proposal = proposals.getFirst();
 
         proposal.setApprovedAt(Instant.now());
-        proposal.setApprovedBy(reviewingUser);
+        proposal.setApprovedBy(currentUserProvider().getUser());
 
         thesisProposalRepository.save(proposal);
 
-        saveStateChange(thesis, ThesisState.WRITING, Instant.now());
+        saveStateChange(thesis, ThesisState.WRITING);
 
         thesis.setState(ThesisState.WRITING);
 
@@ -368,13 +390,14 @@ public class ThesisService {
 
     @Transactional
     public Thesis submitThesis(Thesis thesis) {
+        currentUserProvider().assertCanAccessResearchGroup(thesis.getResearchGroup());
         if (thesis.getLatestFile("THESIS").isEmpty()) {
             throw new ResourceInvalidParametersException("Thesis file not uploaded yet");
         }
 
         thesis.setState(ThesisState.SUBMITTED);
 
-        saveStateChange(thesis, ThesisState.SUBMITTED, Instant.now());
+        saveStateChange(thesis, ThesisState.SUBMITTED);
 
         mailingService.sendFinalSubmissionEmail(thesis);
 
@@ -382,12 +405,13 @@ public class ThesisService {
     }
 
     @Transactional
-    public Thesis uploadThesisFile(User uploader, Thesis thesis, String type, MultipartFile file) {
+    public Thesis uploadThesisFile(Thesis thesis, String type, MultipartFile file) {
+        currentUserProvider().assertCanAccessResearchGroup(thesis.getResearchGroup());
         ThesisFile thesisFile = new ThesisFile();
 
         thesisFile.setUploadName(file.getOriginalFilename());
         thesisFile.setFilename(uploadService.store(file, 20 * 1024 * 1024, UploadFileType.ANY));
-        thesisFile.setUploadedBy(uploader);
+        thesisFile.setUploadedBy(currentUserProvider().getUser());
         thesisFile.setUploadedAt(Instant.now());
         thesisFile.setThesis(thesis);
         thesisFile.setType(type);
@@ -400,6 +424,7 @@ public class ThesisService {
 
     @Transactional
     public Thesis deleteThesisFile(Thesis thesis, UUID fileId) {
+        currentUserProvider().assertCanAccessResearchGroup(thesis.getResearchGroup());
         thesis.getFileById(fileId)
                 .orElseThrow(() -> new ResourceNotFoundException("File id not found"));
 
@@ -413,23 +438,24 @@ public class ThesisService {
     }
 
     public Resource getThesisFile(ThesisFile file) {
+        currentUserProvider().assertCanAccessResearchGroup(file.getResearchGroup());
         return uploadService.load(file.getFilename());
     }
 
     /* ASSESSMENT */
     @Transactional
     public Thesis submitAssessment(
-            User creatingUser,
             Thesis thesis,
             String summary,
             String positives,
             String negatives,
             String gradeSuggestion
     ) {
+        currentUserProvider().assertCanAccessResearchGroup(thesis.getResearchGroup());
         ThesisAssessment assessment = new ThesisAssessment();
 
         assessment.setThesis(thesis);
-        assessment.setCreatedBy(creatingUser);
+        assessment.setCreatedBy(currentUserProvider().getUser());
         assessment.setCreatedAt(Instant.now());
         assessment.setSummary(summary);
         assessment.setPositives(positives);
@@ -444,7 +470,7 @@ public class ThesisService {
         thesis.setAssessments(assessments);
         thesis.setState(ThesisState.ASSESSED);
 
-        saveStateChange(thesis, ThesisState.ASSESSED, Instant.now());
+        saveStateChange(thesis, ThesisState.ASSESSED);
 
         mailingService.sendAssessmentAddedEmail(assessment);
 
@@ -452,6 +478,7 @@ public class ThesisService {
     }
 
     public Resource getAssessmentFile(Thesis thesis) {
+        currentUserProvider().assertCanAccessResearchGroup(thesis.getResearchGroup());
         ThesisAssessment assessment = thesis.getAssessments().getFirst();
         ThesisPresentation presentation = thesis.getPresentations().getFirst();
 
@@ -493,12 +520,13 @@ public class ThesisService {
     /* GRADING */
     @Transactional
     public Thesis gradeThesis(Thesis thesis, String finalGrade, String finalFeedback, ThesisVisibility visibility) {
+        currentUserProvider().assertCanAccessResearchGroup(thesis.getResearchGroup());
         thesis.setState(ThesisState.GRADED);
         thesis.setVisibility(visibility);
         thesis.setFinalGrade(finalGrade);
         thesis.setFinalFeedback(finalFeedback);
 
-        saveStateChange(thesis, ThesisState.GRADED, Instant.now());
+        saveStateChange(thesis, ThesisState.GRADED);
 
         mailingService.sendFinalGradeEmail(thesis);
 
@@ -507,9 +535,10 @@ public class ThesisService {
 
     @Transactional
     public Thesis completeThesis(Thesis thesis) {
+        currentUserProvider().assertCanAccessResearchGroup(thesis.getResearchGroup());
         thesis.setState(ThesisState.FINISHED);
 
-        saveStateChange(thesis, ThesisState.FINISHED, Instant.now());
+        saveStateChange(thesis, ThesisState.FINISHED);
 
         thesis = thesisRepository.save(thesis);
 
@@ -526,6 +555,7 @@ public class ThesisService {
 
     private boolean existsPendingThesis(User user) {
         Page<Thesis> theses = thesisRepository.searchTheses(
+            null,
                 user.getId(),
                 null,
                 null,
@@ -544,17 +574,19 @@ public class ThesisService {
     }
 
     public Thesis findById(UUID thesisId) {
-        return thesisRepository.findById(thesisId)
+        Thesis thesis = thesisRepository.findById(thesisId)
                 .orElseThrow(() -> new ResourceNotFoundException(String.format("Thesis with id %s not found.", thesisId)));
+        currentUserProvider().assertCanAccessResearchGroup(thesis.getResearchGroup());
+        return thesis;
     }
 
     private void assignThesisRoles(
             Thesis thesis,
-            User assigner,
             List<UUID> supervisorIds,
             List<UUID> advisorIds,
             List<UUID> studentIds
     ) {
+        currentUserProvider().assertCanAccessResearchGroup(thesis.getResearchGroup());
         List<User> supervisors = userRepository.findAllById(supervisorIds);
         List<User> advisors = userRepository.findAllById(advisorIds);
         List<User> students = userRepository.findAllById(studentIds);
@@ -585,7 +617,7 @@ public class ThesisService {
                 throw new ResourceInvalidParametersException("User is not a supervisor");
             }
 
-            saveThesisRole(thesis, assigner, supervisor, ThesisRoleName.SUPERVISOR, i);
+            saveThesisRole(thesis, supervisor, ThesisRoleName.SUPERVISOR, i);
         }
 
         for (int i = 0; i < advisors.size(); i++) {
@@ -595,16 +627,17 @@ public class ThesisService {
                 throw new ResourceInvalidParametersException("User is not an advisor");
             }
 
-            saveThesisRole(thesis, assigner, advisor, ThesisRoleName.ADVISOR, i);
+            saveThesisRole(thesis, advisor, ThesisRoleName.ADVISOR, i);
         }
 
         for (int i = 0; i < students.size(); i++) {
             User student = students.get(i);
-            saveThesisRole(thesis, assigner, student, ThesisRoleName.STUDENT, i);
+            saveThesisRole(thesis, student, ThesisRoleName.STUDENT, i);
         }
     }
 
-    private void saveStateChange(Thesis thesis, ThesisState state, Instant changedAt) {
+    private void saveStateChange(Thesis thesis, ThesisState state) {
+        currentUserProvider().assertCanAccessResearchGroup(thesis.getResearchGroup());
         ThesisStateChangeId stateChangeId = new ThesisStateChangeId();
         stateChangeId.setThesisId(thesis.getId());
         stateChangeId.setState(state);
@@ -612,7 +645,7 @@ public class ThesisService {
         ThesisStateChange stateChange = new ThesisStateChange();
         stateChange.setId(stateChangeId);
         stateChange.setThesis(thesis);
-        stateChange.setChangedAt(changedAt);
+        stateChange.setChangedAt(Instant.now());
 
         thesisStateChangeRepository.save(stateChange);
 
@@ -621,7 +654,9 @@ public class ThesisService {
         thesis.setStates(stateChanges);
     }
 
-    private void saveThesisRole(Thesis thesis, User assigner, User user, ThesisRoleName role, int position) {
+    private void saveThesisRole(Thesis thesis, User user, ThesisRoleName role, int position) {
+        currentUserProvider().assertCanAccessResearchGroup(thesis.getResearchGroup());
+        User assigner = currentUserProvider().getUser();
         if (assigner == null || user == null) {
             throw new ResourceInvalidParametersException("Assigner and user must be provided.");
         }

--- a/server/src/main/java/de/tum/cit/aet/thesis/service/TopicService.java
+++ b/server/src/main/java/de/tum/cit/aet/thesis/service/TopicService.java
@@ -45,6 +45,7 @@ public class TopicService {
     }
 
     public Page<Topic> getAll(
+            boolean onlyOwnResearchGroup,
             String[] types,
             boolean includeClosed,
             String searchQuery,
@@ -58,7 +59,8 @@ public class TopicService {
                 HibernateHelper.getColumnName(Topic.class, sortBy)
         );
 
-        ResearchGroup researchGroup = currentUserProvider().getResearchGroupOrThrow();
+        ResearchGroup researchGroup = onlyOwnResearchGroup ?
+            currentUserProvider().getResearchGroupOrThrow() : null;
         String searchQueryFilter = searchQuery == null || searchQuery.isEmpty() ? null : searchQuery.toLowerCase();
         String[] typesFilter = types == null || types.length == 0 ? null : types;
 

--- a/server/src/main/java/de/tum/cit/aet/thesis/service/UserService.java
+++ b/server/src/main/java/de/tum/cit/aet/thesis/service/UserService.java
@@ -60,9 +60,7 @@ public class UserService {
     }
 
     public User findById(UUID userId) {
-        User user = userRepository.findById(userId)
+        return userRepository.findById(userId)
                 .orElseThrow(() -> new ResourceNotFoundException(String.format("User with id %s not found.", userId)));
-        currentUserProvider().assertCanAccessResearchGroup(user.getResearchGroup());
-        return user;
     }
 }

--- a/server/src/main/java/de/tum/cit/aet/thesis/service/UserService.java
+++ b/server/src/main/java/de/tum/cit/aet/thesis/service/UserService.java
@@ -1,5 +1,8 @@
 package de.tum.cit.aet.thesis.service;
 
+import de.tum.cit.aet.thesis.entity.ResearchGroup;
+import de.tum.cit.aet.thesis.security.CurrentUserProvider;
+import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.io.Resource;
 import org.springframework.data.domain.Page;
@@ -19,21 +22,29 @@ import java.util.UUID;
 public class UserService {
     private final UserRepository userRepository;
     private final UploadService uploadService;
+    private final ObjectProvider<CurrentUserProvider> currentUserProviderProvider;
 
     @Autowired
-    public UserService(UserRepository userRepository, UploadService uploadService) {
+    public UserService(UserRepository userRepository, UploadService uploadService,
+        ObjectProvider<CurrentUserProvider> currentUserProviderProvider) {
         this.userRepository = userRepository;
         this.uploadService = uploadService;
+        this.currentUserProviderProvider = currentUserProviderProvider;
+    }
+
+    private CurrentUserProvider currentUserProvider() {
+        return currentUserProviderProvider.getObject();
     }
 
     public Page<User> getAll(String searchQuery, String[] groups, Integer page, Integer limit, String sortBy, String sortOrder) {
         Sort.Order order = new Sort.Order(sortOrder.equals("asc") ? Sort.Direction.ASC : Sort.Direction.DESC, sortBy);
 
+        ResearchGroup researchGroup = currentUserProvider().getResearchGroupOrThrow();
         String searchQueryFilter = searchQuery == null || searchQuery.isEmpty() ? null : searchQuery.toLowerCase();
         Set<String> groupsFilter = groups == null || groups.length == 0 ? null : new HashSet<>(Arrays.asList(groups));
 
         return userRepository
-                .searchUsers(searchQueryFilter, groupsFilter, PageRequest.of(page, limit, Sort.by(order)));
+                .searchUsers(researchGroup == null ? null : researchGroup.getId(),searchQueryFilter, groupsFilter, PageRequest.of(page, limit, Sort.by(order)));
     }
 
     public Resource getExaminationReport(User user) {
@@ -49,7 +60,9 @@ public class UserService {
     }
 
     public User findById(UUID userId) {
-        return userRepository.findById(userId)
+        User user = userRepository.findById(userId)
                 .orElseThrow(() -> new ResourceNotFoundException(String.format("User with id %s not found.", userId)));
+        currentUserProvider().assertCanAccessResearchGroup(user.getResearchGroup());
+        return user;
     }
 }

--- a/server/src/main/java/de/tum/cit/aet/thesis/utility/MailBuilder.java
+++ b/server/src/main/java/de/tum/cit/aet/thesis/utility/MailBuilder.java
@@ -140,8 +140,8 @@ public class MailBuilder {
 
     }
 
-    public MailBuilder sendToChairMembers() {
-        for (User user : config.getChairMembers()) {
+    public MailBuilder sendToChairMembers(UUID researchGroupId) {
+        for (User user : config.getChairMembers(researchGroupId)) {
             addPrimaryRecipient(user);
         }
 

--- a/server/src/main/java/de/tum/cit/aet/thesis/utility/MailConfig.java
+++ b/server/src/main/java/de/tum/cit/aet/thesis/utility/MailConfig.java
@@ -76,12 +76,12 @@ public class MailConfig {
         return enabled;
     }
 
-    public List<User> getChairMembers() {
-        return userRepository.getRoleMembers(Set.of("admin", "supervisor", "advisor"));
+    public List<User> getChairMembers(UUID researchGroupId) {
+        return userRepository.getRoleMembers(Set.of("admin", "supervisor", "advisor"), researchGroupId);
     }
 
-    public List<User> getChairStudents() {
-        return userRepository.getRoleMembers(Set.of("student"));
+    public List<User> getChairStudents(UUID researchGroupId) {
+        return userRepository.getRoleMembers(Set.of("student"), researchGroupId);
     }
 
     public record MailConfigDto(


### PR DESCRIPTION
### ✨ Summary  

This PR introduces a secure and scalable way to filter all backend API calls by the authenticated user’s assigned research group. It ensures that only authorized users (e.g., advisors, supervisors, professors) can access data from their research group and blocks unauthorized access to other groups’ data. It also replaces the direct injection of @RequestScope beans and improves maintainability across services and controllers.

---

### 🧩What's Included  

- Introduced CurrentUserProvider to manage access control and user context based on the research group
- Filtered access to Thesis, Application, Topic, User, and related entities via centralized access checks
- Updated all controller injections to use ObjectProvider<CurrentUserProvider> instead of directly wiring request-scoped beans
- Migrated all access control logic from the controller level into service-level authorization methods
- Updated client to pass and render research group information where needed
- Updated application, thesis, topic, and presentation services and repositories to enforce research group boundaries
- New postman collection for easy server/endpoint testing

---

### 🛠️ New Classes  

#### Controller & Security  
- CurrentUserProvider: central utility to resolve current user, role, and research group scope
- Updated all affected controllers (ApplicationController, UserController, ThesisController, etc.) to use this provider

---

### 📡 New API Endpoints  

| Method | Path                                            | Description                           | Auth Required |
|--------|-------------------------------------------------|---------------------------------------|---------------|
|-|(all relevant endpoints)|now automatically filtered by user's research group|✅|

---

### 🧪 Migration Notes  
- All users (advisor, supervisor, admin) must be assigned to a research group in the database
- Students are not scoped and continue to see all public data
- Admins retain unrestricted access
- If research_group_id is missing on the user, access is denied for scoped roles

---

### 🔮 Next Steps  

- Implement different mail templates for different research groups