### PR TITLE
Add new error message to display and change logic of displaying uploa…

### DIFF
--- a/client/src/pages/ThesisPage/components/ThesisWritingSection/ThesisWritingSection.tsx
+++ b/client/src/pages/ThesisPage/components/ThesisWritingSection/ThesisWritingSection.tsx
@@ -54,10 +54,14 @@ const ThesisWritingSection = () => {
 
     if (response.ok) {
       showSimpleSuccess('File uploaded successfully')
-
       updateThesis(response.data)
     } else {
-      showSimpleError(getApiResponseErrorMessage(response))
+      if (access.student && thesis.state === ThesisState.SUBMITTED) {
+        // It is not possible to return this message in the endpoint, because the frontend already catches that the student is not permitted to submit
+        showSimpleError('Cannot upload files after final submission. Please contact your advisor.')
+      } else {
+        showSimpleError(getApiResponseErrorMessage(response))
+      }
     }
   }
 
@@ -201,8 +205,7 @@ const ThesisWritingSection = () => {
                                       </AuthenticatedFileDownloadButton>
                                     )}
                                     {((access.student && thesis.state === ThesisState.WRITING) ||
-                                      access.advisor ||
-                                      (access.student && !value.required)) &&
+                                      access.advisor) &&
                                       !isThesisClosed(thesis) && (
                                         <UploadFileButton
                                           onUpload={(file) => onFileUpload(key, file)}

--- a/client/src/pages/ThesisPage/components/ThesisWritingSection/ThesisWritingSection.tsx
+++ b/client/src/pages/ThesisPage/components/ThesisWritingSection/ThesisWritingSection.tsx
@@ -57,7 +57,7 @@ const ThesisWritingSection = () => {
       updateThesis(response.data)
     } else {
       if (access.student && thesis.state === ThesisState.SUBMITTED) {
-        // It is not possible to return this message in the endpoint, because the frontend already catches that the student is not permitted to submit
+        // It is not possible to return this message in the endpoint, the client already catches that the student is not permitted to submit and returns a 403
         showSimpleError('Cannot upload files after final submission. Please contact your advisor.')
       } else {
         showSimpleError(getApiResponseErrorMessage(response))


### PR DESCRIPTION
Trying to upload a presentation as a student, returns now a proper error ('Cannot upload files after final submission. Please contact your advisor.').
The endpoint would already return this error but the client has a extra security layer where it checks the auth before sending out the request resulting in a generic error message. That's why I only added it as edge case to the client.
The logic for getting upload buttons displayed was changed.