### PR TITLE
Increase file upload limit to 25MB

### DIFF
--- a/client/src/components/ThesisCommentsForm/ThesisCommentsForm.tsx
+++ b/client/src/components/ThesisCommentsForm/ThesisCommentsForm.tsx
@@ -23,7 +23,7 @@ const ThesisCommentsForm = () => {
         value={message}
         onChange={(e) => setMessage(e.target.value)}
         rightSection={
-          <UploadFileButton onUpload={setFile} maxSize={20 * 1024 * 1024} accept='any' size='xs'>
+          <UploadFileButton onUpload={setFile} maxSize={25 * 1024 * 1024} accept='any' size='xs'>
             <Upload />
           </UploadFileButton>
         }

--- a/client/src/pages/ThesisPage/components/ThesisProposalSection/ThesisProposalSection.tsx
+++ b/client/src/pages/ThesisPage/components/ThesisProposalSection/ThesisProposalSection.tsx
@@ -79,7 +79,7 @@ const ThesisProposalSection = () => {
                   !isThesisClosed(thesis) ? (
                     <UploadFileButton
                       onUpload={onUpload}
-                      maxSize={20 * 1024 * 1024}
+                      maxSize={25 * 1024 * 1024}
                       accept='pdf'
                       ml='auto'
                     >
@@ -93,7 +93,7 @@ const ThesisProposalSection = () => {
               <Stack>
                 <Text ta='center'>No proposal uploaded yet</Text>
                 <Center>
-                  <UploadFileButton onUpload={onUpload} maxSize={20 * 1024 * 1024} accept='pdf'>
+                  <UploadFileButton onUpload={onUpload} maxSize={25 * 1024 * 1024} accept='pdf'>
                     Upload Proposal
                   </UploadFileButton>
                 </Center>

--- a/client/src/pages/ThesisPage/components/ThesisWritingSection/ThesisWritingSection.tsx
+++ b/client/src/pages/ThesisPage/components/ThesisWritingSection/ThesisWritingSection.tsx
@@ -118,7 +118,7 @@ const ThesisWritingSection = () => {
                                 access.advisor) &&
                               !isThesisClosed(thesis) ? (
                                 <UploadFileButton
-                                  maxSize={20 * 1024 * 1024}
+                                  maxSize={25 * 1024 * 1024}
                                   accept='pdf'
                                   onUpload={(file) => onFileUpload('THESIS', file)}
                                 >
@@ -132,7 +132,7 @@ const ThesisWritingSection = () => {
                             <Text ta='center'>No thesis uploaded yet</Text>
                             <Center>
                               <UploadFileButton
-                                maxSize={20 * 1024 * 1024}
+                                maxSize={25 * 1024 * 1024}
                                 accept='pdf'
                                 onUpload={(file) => onFileUpload('THESIS', file)}
                               >
@@ -206,7 +206,7 @@ const ThesisWritingSection = () => {
                                       !isThesisClosed(thesis) && (
                                         <UploadFileButton
                                           onUpload={(file) => onFileUpload(key, file)}
-                                          maxSize={20 * 1024 * 1024}
+                                          maxSize={25 * 1024 * 1024}
                                           accept={value.accept}
                                           size='xs'
                                         >

--- a/server/src/main/java/de/tum/cit/aet/thesis/service/ThesisCommentService.java
+++ b/server/src/main/java/de/tum/cit/aet/thesis/service/ThesisCommentService.java
@@ -59,7 +59,7 @@ public class ThesisCommentService {
 
         if (file != null) {
             comment.setUploadName(file.getOriginalFilename());
-            comment.setFilename(uploadService.store(file, 20 * 1024 * 1024, UploadFileType.ANY));
+            comment.setFilename(uploadService.store(file, 25 * 1024 * 1024, UploadFileType.ANY));
         }
 
         comment = thesisCommentRepository.save(comment);

--- a/server/src/main/java/de/tum/cit/aet/thesis/service/ThesisService.java
+++ b/server/src/main/java/de/tum/cit/aet/thesis/service/ThesisService.java
@@ -355,7 +355,7 @@ public class ThesisService {
         ThesisProposal proposal = new ThesisProposal();
 
         proposal.setThesis(thesis);
-        proposal.setProposalFilename(uploadService.store(proposalFile, 20 * 1024 * 1024, UploadFileType.PDF));
+        proposal.setProposalFilename(uploadService.store(proposalFile, 25 * 1024 * 1024, UploadFileType.PDF));
         proposal.setCreatedAt(Instant.now());
         proposal.setCreatedBy(currentUserProvider().getUser());
 
@@ -435,7 +435,7 @@ public class ThesisService {
         ThesisFile thesisFile = new ThesisFile();
 
         thesisFile.setUploadName(file.getOriginalFilename());
-        thesisFile.setFilename(uploadService.store(file, 20 * 1024 * 1024, UploadFileType.ANY));
+        thesisFile.setFilename(uploadService.store(file, 25 * 1024 * 1024, UploadFileType.ANY));
         thesisFile.setUploadedBy(currentUserProvider().getUser());
         thesisFile.setUploadedAt(Instant.now());
         thesisFile.setThesis(thesis);

--- a/server/src/main/resources/application.yml
+++ b/server/src/main/resources/application.yml
@@ -24,8 +24,8 @@ spring:
         format_sql: ${DEBUG_MODE:false}
   servlet:
     multipart:
-      max-file-size: 20MB
-      max-request-size: 20MB
+      max-file-size: 25MB
+      max-request-size: 25MB
   security:
     oauth2:
       client:

--- a/server/src/test/resources/application.yml
+++ b/server/src/test/resources/application.yml
@@ -24,8 +24,8 @@ spring:
         format_sql: false
   servlet:
     multipart:
-      max-file-size: 20MB
-      max-request-size: 20MB
+      max-file-size: 25MB
+      max-request-size: 25MB
   mail:
     host: localhost
     port: 25


### PR DESCRIPTION
This pull request increases the maximum file upload size across the application from 20 MB to 25 MB. The changes affect both the client-side components and server-side logic, as well as configuration files for file upload limits.
This change is necessary because some students have had problems upload their slide sources due to the current size limit.