### PR TITLE
Development: Fix student selection bug

### DIFF
--- a/server/src/main/java/de/tum/cit/aet/thesis/repository/UserRepository.java
+++ b/server/src/main/java/de/tum/cit/aet/thesis/repository/UserRepository.java
@@ -21,21 +21,21 @@ public interface UserRepository extends JpaRepository<User, UUID> {
     Optional<User> findByUniversityIdWithResearchGroup(@Param("universityId") String universityId);
 
     @Query("""
-              SELECT DISTINCT u
-              FROM User u
-              LEFT JOIN UserGroup g ON (u.id = g.id.userId)
-              WHERE (:researchGroupId IS NULL
-                     OR NOT ('advisor' IN :groups
-                             OR 'supervisor' IN :groups)
-                     OR u.researchGroup.id = :researchGroupId)
-                AND ((:groups IS NULL)
+            SELECT DISTINCT u
+            FROM User u
+            LEFT JOIN UserGroup g ON (u.id = g.id.userId)
+            WHERE (:researchGroupId IS NULL
+                   OR NOT ('advisor' IN :groups
+                           OR 'supervisor' IN :groups)
+                   OR u.researchGroup.id = :researchGroupId)
+              AND ((:groups IS NULL)
                      OR ('student' IN :groups AND (g.id.group IN :groups OR g.id.group IS NULL))
                      OR g.id.group IN :groups)
-                AND (:searchQuery IS NULL
-                     OR LOWER(u.firstName) || ' ' || LOWER(u.lastName) LIKE %:searchQuery%
-                     OR LOWER(u.email) LIKE %:searchQuery%
-                     OR LOWER(u.matriculationNumber) LIKE %:searchQuery%
-                     OR LOWER(u.universityId) LIKE %:searchQuery%)
+              AND (:searchQuery IS NULL
+                   OR LOWER(u.firstName) || ' ' || LOWER(u.lastName) LIKE %:searchQuery%
+                   OR LOWER(u.email) LIKE %:searchQuery%
+                   OR LOWER(u.matriculationNumber) LIKE %:searchQuery%
+                   OR LOWER(u.universityId) LIKE %:searchQuery%)
             """)
     Page<User> searchUsers(@Param("researchGroupId") UUID researchGroupId,
                            @Param("searchQuery") String searchQuery, @Param("groups") Set<String> groups, Pageable page);

--- a/server/src/main/java/de/tum/cit/aet/thesis/repository/UserRepository.java
+++ b/server/src/main/java/de/tum/cit/aet/thesis/repository/UserRepository.java
@@ -21,20 +21,21 @@ public interface UserRepository extends JpaRepository<User, UUID> {
     Optional<User> findByUniversityIdWithResearchGroup(@Param("universityId") String universityId);
 
     @Query("""
-            SELECT DISTINCT u
-            FROM User u
-            LEFT JOIN UserGroup g ON (u.id = g.id.userId)
-            WHERE (:researchGroupId IS NULL
-                   OR NOT ('advisor' IN :groups
-                           OR 'supervisor' IN :groups)
-                   OR u.researchGroup.id = :researchGroupId)
-              AND (:groups IS NULL
-                   OR g.id.group IN :groups)
-              AND (:searchQuery IS NULL
-                   OR LOWER(u.firstName) || ' ' || LOWER(u.lastName) LIKE %:searchQuery%
-                   OR LOWER(u.email) LIKE %:searchQuery%
-                   OR LOWER(u.matriculationNumber) LIKE %:searchQuery%
-                   OR LOWER(u.universityId) LIKE %:searchQuery%)
+              SELECT DISTINCT u
+              FROM User u
+              LEFT JOIN UserGroup g ON (u.id = g.id.userId)
+              WHERE (:researchGroupId IS NULL
+                     OR NOT ('advisor' IN :groups
+                             OR 'supervisor' IN :groups)
+                     OR u.researchGroup.id = :researchGroupId)
+                AND ((:groups IS NULL)
+                     OR ('student' IN :groups AND (g.id.group IN :groups OR g.id.group IS NULL))
+                     OR g.id.group IN :groups)
+                AND (:searchQuery IS NULL
+                     OR LOWER(u.firstName) || ' ' || LOWER(u.lastName) LIKE %:searchQuery%
+                     OR LOWER(u.email) LIKE %:searchQuery%
+                     OR LOWER(u.matriculationNumber) LIKE %:searchQuery%
+                     OR LOWER(u.universityId) LIKE %:searchQuery%)
             """)
     Page<User> searchUsers(@Param("researchGroupId") UUID researchGroupId,
                            @Param("searchQuery") String searchQuery, @Param("groups") Set<String> groups, Pageable page);


### PR DESCRIPTION
This PR fixes an issue where students who had recently signed up and had not yet been assigned to a user group were excluded from the search results. This affected cases where users were searched specifically as students.