### PR TITLE
Add a overload function to set the state not only to the current Date

### DIFF
--- a/server/src/main/java/de/tum/cit/aet/thesis/service/ThesisService.java
+++ b/server/src/main/java/de/tum/cit/aet/thesis/service/ThesisService.java
@@ -227,7 +227,7 @@ public class ThesisService {
         assignThesisRoles(thesis, supervisorIds, advisorIds, studentIds);
 
         for (ThesisStatePayload state : states) {
-            saveStateChange(thesis, state.state());
+            saveStateChange(thesis, state.state(), state.changedAt());
         }
 
         thesis = thesisRepository.save(thesis);
@@ -662,6 +662,10 @@ public class ThesisService {
     }
 
     private void saveStateChange(Thesis thesis, ThesisState state) {
+        saveStateChange(thesis, state, Instant.now());
+    }
+
+    private void saveStateChange(Thesis thesis, ThesisState state, Instant changedAt) {
         currentUserProvider().assertCanAccessResearchGroup(thesis.getResearchGroup());
         ThesisStateChangeId stateChangeId = new ThesisStateChangeId();
         stateChangeId.setThesisId(thesis.getId());
@@ -670,7 +674,7 @@ public class ThesisService {
         ThesisStateChange stateChange = new ThesisStateChange();
         stateChange.setId(stateChangeId);
         stateChange.setThesis(thesis);
-        stateChange.setChangedAt(Instant.now());
+        stateChange.setChangedAt(changedAt);
 
         thesisStateChangeRepository.save(stateChange);
 


### PR DESCRIPTION
This PR allows setting a custom timestamp when saving a ThesisStateChange, instead of always using Instant.now(). It introduces an overloaded method to avoid null checks while keeping the original method unchanged for default behavior.