### PR TITLE
Limit Pages to 12 items on Landing page

### DIFF
--- a/client/src/pages/LandingPage/LandingPage.tsx
+++ b/client/src/pages/LandingPage/LandingPage.tsx
@@ -51,6 +51,8 @@ const LandingPage = () => {
     searchParams.get('groups')?.split(',') ?? [],
   )
 
+  let pageItemLimit = 12
+
   useEffect(() => {
     const params = new URLSearchParams(searchParams)
 
@@ -256,7 +258,7 @@ const LandingPage = () => {
         )}
       </Flex>
       <TopicsProvider
-        limit={10}
+        limit={pageItemLimit}
         researchSpecific={false}
         initialFilters={{
           researchGroupIds: researchGroupId ? [researchGroupId] : selectedGroups,
@@ -308,6 +310,7 @@ const LandingPage = () => {
                 researchGroupIds: researchGroupId ? [researchGroupId] : selectedGroups,
                 types: selectedThesisTypes,
               }}
+              limit={pageItemLimit}
             />
           )}
         </Stack>

--- a/client/src/pages/LandingPage/components/PublishedTheses/PublishedTheses.tsx
+++ b/client/src/pages/LandingPage/components/PublishedTheses/PublishedTheses.tsx
@@ -22,11 +22,12 @@ interface PublishedThesesProps {
     researchGroupIds?: string[]
     types?: string[]
   }
+  limit?: number
 }
 
-const PublishedTheses = ({ search, representationType, filters }: PublishedThesesProps) => {
+const PublishedTheses = ({ search, representationType, filters, limit }: PublishedThesesProps) => {
   const [page, setPage] = useState(0)
-  const limit = 10
+  limit = limit ?? 10
 
   const [theses, setTheses] = useState<PaginationResponse<IPublishedThesis>>()
   const [openedThesis, setOpenedThesis] = useState<IPublishedThesis>()

--- a/client/src/pages/LandingPage/components/TopicCardGrid/TopicCardGrid.tsx
+++ b/client/src/pages/LandingPage/components/TopicCardGrid/TopicCardGrid.tsx
@@ -60,7 +60,11 @@ const TopicCardGrid = ({ gridContent, setOpenTopic }: ITopicCardGridContentProps
             verticalSpacing={{ base: 'xs', sm: 'sm', xl: 'md' }}
           >
             {topics?.content.map((topic) => (
-              <TopicCard key={topic.title} topic={topic} setOpenTopic={setOpenTopic} />
+              <TopicCard
+                key={'topicId' in topic ? topic.topicId : topic.thesisId}
+                topic={topic}
+                setOpenTopic={setOpenTopic}
+              />
             ))}
           </SimpleGrid>
         )}


### PR DESCRIPTION
Changed the Limit to 12 so that the number is divisible by 2 and 3.
Also fixing a small bug that would appear if 2 theses have the exact same name.