### PR TITLE
Bugfix: Allow to assign group-admin independent of researchgroup

### DIFF
--- a/server/src/main/java/de/tum/cit/aet/thesis/service/AccessManagementService.java
+++ b/server/src/main/java/de/tum/cit/aet/thesis/service/AccessManagementService.java
@@ -164,10 +164,6 @@ public class AccessManagementService {
             throw new RuntimeException("User is null");
         }
 
-        if (user.getResearchGroup() == null) {
-            throw new RuntimeException("User is not part of a research group");
-        }
-
         try {
             UUID userId = getUserId(user.getUniversityId());
             assignKeycloakRole(userId, "group-admin");


### PR DESCRIPTION
When creating a researchGroup the head is not yet part of a group but we still want to assign him group-admin rights