### PR TITLE
Fix process nav highlight snapping back to Overview on click

### DIFF
--- a/client/src/thesis/pages/ThesisPage/components/ThesisProcessNav/ThesisProcessNav.tsx
+++ b/client/src/thesis/pages/ThesisPage/components/ThesisProcessNav/ThesisProcessNav.tsx
@@ -40,7 +40,7 @@ const scrollToSection = (id: string) => {
 const ThesisProcessNav = ({ steps }: IThesisProcessNavProps) => {
   const theme = useMantineTheme()
   const headerOffset = getAppShellHeaderOffset()
-  const activeId = useActiveSection(
+  const [activeId, setActiveSection] = useActiveSection(
     steps.map((s) => s.id),
     headerOffset + 60,
   )
@@ -126,7 +126,10 @@ const ThesisProcessNav = ({ steps }: IThesisProcessNavProps) => {
                   />
                 )}
                 <UnstyledButton
-                  onClick={() => scrollToSection(step.id)}
+                  onClick={() => {
+                    setActiveSection(step.id)
+                    scrollToSection(step.id)
+                  }}
                   style={pillStyle}
                   aria-current={active ? 'step' : undefined}
                 >

--- a/client/src/thesis/pages/ThesisPage/components/ThesisProcessNav/ThesisProcessNav.tsx
+++ b/client/src/thesis/pages/ThesisPage/components/ThesisProcessNav/ThesisProcessNav.tsx
@@ -28,12 +28,25 @@ const scrollToSection = (id: string) => {
   if (!el) {
     return
   }
-  // Open any collapsed accordion controls inside this section so the panel is
-  // visible once the user lands on it — otherwise a nav click can scroll to a
-  // section whose body is still hidden.
+  // Reveal a collapsed accordion so the user doesn't land on a section whose
+  // body is still hidden — but only when the accordion is *fully* collapsed.
+  // In a single-select accordion one item is already open, so clicking a closed
+  // control there would merely toggle the open sibling shut (e.g. flipping the
+  // Files/Comments panels in the Writing section on every nav click).
   el.querySelectorAll<HTMLButtonElement>(
     'button.mantine-Accordion-control[aria-expanded="false"]',
-  ).forEach((btn) => btn.click())
+  ).forEach((btn) => {
+    const root = btn.closest('.mantine-Accordion-item')?.parentElement
+    const siblingHasOpenPanel = root
+      ? Array.from(root.children)
+          .filter((child) => child.classList.contains('mantine-Accordion-item'))
+          .map((item) => item.querySelector('.mantine-Accordion-control'))
+          .some((control) => control?.getAttribute('aria-expanded') === 'true')
+      : false
+    if (!siblingHasOpenPanel) {
+      btn.click()
+    }
+  })
   el.scrollIntoView({ behavior: 'smooth', block: 'start' })
 }
 

--- a/client/src/thesis/pages/ThesisPage/hooks/useActiveSection.ts
+++ b/client/src/thesis/pages/ThesisPage/hooks/useActiveSection.ts
@@ -1,13 +1,44 @@
-import { useEffect, useState } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
+
+// Keys that scroll the page — a keydown from one of these counts as the user
+// taking over navigation and releases a click lock (see below). Plain typing in
+// an input must not release it, so unrelated keys are ignored.
+const SCROLL_KEYS = new Set([
+  'ArrowUp',
+  'ArrowDown',
+  'PageUp',
+  'PageDown',
+  'Home',
+  'End',
+  ' ',
+  'Spacebar',
+])
 
 /**
  * Tracks which of the given section anchor ids is currently in view. Uses
  * IntersectionObserver with a top offset so a section counts as "active" once
  * it scrolls above the sticky navbar rather than only when centered.
+ *
+ * Returns the active id plus a `setActiveSection` setter. Call the setter when
+ * the user clicks a nav item: it highlights that section immediately and locks
+ * the scroll spy so it can't snap the highlight back. Without the lock, clicking
+ * a nav item on a short/collapsed page (where the target can't scroll all the
+ * way to the top) would leave whatever sits at the top — usually "Overview" —
+ * highlighted, which is misleading. The lock is released as soon as the user
+ * scrolls the page themselves, after which the scroll spy resumes tracking.
  */
-export function useActiveSection(sectionIds: string[], topOffset = 100): string | null {
+export function useActiveSection(
+  sectionIds: string[],
+  topOffset = 100,
+): [string | null, (id: string) => void] {
   const [activeId, setActiveId] = useState<string | null>(sectionIds[0] ?? null)
   const key = sectionIds.join('|')
+  const lockedRef = useRef(false)
+
+  const setActiveSection = useCallback((id: string) => {
+    lockedRef.current = true
+    setActiveId(id)
+  }, [])
 
   useEffect(() => {
     if (sectionIds.length === 0) {
@@ -44,6 +75,12 @@ export function useActiveSection(sectionIds: string[], topOffset = 100): string 
     }
 
     const pickActive = () => {
+      // A click lock pins the highlight to the user's chosen section until they
+      // scroll the page themselves, so don't override it here.
+      if (lockedRef.current) {
+        return
+      }
+
       if (isScrolledToBottom()) {
         setActiveId(elements[elements.length - 1].id)
         return
@@ -84,12 +121,32 @@ export function useActiveSection(sectionIds: string[], topOffset = 100): string 
     const onScroll = () => pickActive()
     window.addEventListener('scroll', onScroll, { passive: true, capture: true })
 
+    // A genuine user-initiated scroll releases the click lock so the scroll spy
+    // resumes tracking the real scroll position.
+    const releaseLock = () => {
+      if (lockedRef.current) {
+        lockedRef.current = false
+        pickActive()
+      }
+    }
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (SCROLL_KEYS.has(event.key)) {
+        releaseLock()
+      }
+    }
+    window.addEventListener('wheel', releaseLock, { passive: true, capture: true })
+    window.addEventListener('touchmove', releaseLock, { passive: true, capture: true })
+    window.addEventListener('keydown', onKeyDown, { passive: true, capture: true })
+
     return () => {
       observer.disconnect()
       window.removeEventListener('scroll', onScroll, true)
+      window.removeEventListener('wheel', releaseLock, true)
+      window.removeEventListener('touchmove', releaseLock, true)
+      window.removeEventListener('keydown', onKeyDown, true)
     }
     // eslint-disable-next-line @eslint-react/exhaustive-deps -- `key` (joined ids) captures the array identity
   }, [key, topOffset])
 
-  return activeId
+  return [activeId, setActiveSection]
 }

--- a/client/src/thesis/pages/ThesisPage/hooks/useActiveSection.ts
+++ b/client/src/thesis/pages/ThesisPage/hooks/useActiveSection.ts
@@ -1,8 +1,7 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
 
-// Keys that scroll the page — a keydown from one of these counts as the user
-// taking over navigation and releases a click lock (see below). Plain typing in
-// an input must not release it, so unrelated keys are ignored.
+// Keys that scroll the page — a keydown from one of these arms a click-lock
+// release (see below). Unrelated keys (plain typing) are ignored.
 const SCROLL_KEYS = new Set([
   'ArrowUp',
   'ArrowDown',
@@ -13,6 +12,14 @@ const SCROLL_KEYS = new Set([
   ' ',
   'Spacebar',
 ])
+
+// Space/arrow keys also edit text and move the caret, so a keydown inside an
+// editable control must never arm a release.
+const isEditableTarget = (target: EventTarget | null): boolean =>
+  target instanceof HTMLInputElement ||
+  target instanceof HTMLTextAreaElement ||
+  target instanceof HTMLSelectElement ||
+  (target instanceof HTMLElement && target.isContentEditable)
 
 /**
  * Tracks which of the given section anchor ids is currently in view. Uses
@@ -34,9 +41,14 @@ export function useActiveSection(
   const [activeId, setActiveId] = useState<string | null>(sectionIds[0] ?? null)
   const key = sectionIds.join('|')
   const lockedRef = useRef(false)
+  // Whether a user scroll gesture has "armed" a lock release (see the effect).
+  const armedRef = useRef(false)
 
   const setActiveSection = useCallback((id: string) => {
     lockedRef.current = true
+    // Discard any gesture armed before this click so the programmatic scroll
+    // that follows can't immediately release the fresh lock.
+    armedRef.current = false
     setActiveId(id)
   }, [])
 
@@ -55,6 +67,23 @@ export function useActiveSection(
 
     const visibility = new Map<string, number>()
 
+    // The page may scroll on the window or on a scrollable ancestor (AppShell.Main).
+    const scrollAncestor = (() => {
+      let el: HTMLElement | null = elements[elements.length - 1].parentElement
+      while (el) {
+        const overflowY = getComputedStyle(el).overflowY
+        if (overflowY === 'auto' || overflowY === 'scroll') {
+          return el
+        }
+        el = el.parentElement
+      }
+      return null
+    })()
+
+    // Combined vertical scroll offset. Horizontal gestures (e.g. swiping the
+    // nav's own ScrollArea) don't change this, so they won't release the lock.
+    const getVerticalScroll = () => window.scrollY + (scrollAncestor?.scrollTop ?? 0)
+
     const isScrolledToBottom = () => {
       // Handles both window scrolling and any scrollable ancestor with fixed height.
       const doc = document.documentElement
@@ -62,14 +91,11 @@ export function useActiveSection(
       if (winBottom) {
         return true
       }
-      // Also check the closest scroll ancestor of the last section (AppShell.Main).
-      let el: HTMLElement | null = elements[elements.length - 1].parentElement
-      while (el) {
-        const overflowY = getComputedStyle(el).overflowY
-        if (overflowY === 'auto' || overflowY === 'scroll') {
-          return Math.ceil(el.scrollTop + el.clientHeight) >= el.scrollHeight - 2
-        }
-        el = el.parentElement
+      if (scrollAncestor) {
+        return (
+          Math.ceil(scrollAncestor.scrollTop + scrollAncestor.clientHeight) >=
+          scrollAncestor.scrollHeight - 2
+        )
       }
       return false
     }
@@ -116,33 +142,44 @@ export function useActiveSection(
 
     elements.forEach((el) => observer.observe(el))
 
-    // Fallback scroll listener catches the "scrolled past the observer's active
-    // band" case for short final sections that never trip the intersection.
-    const onScroll = () => pickActive()
+    // Releasing the click lock takes two signals: a scroll gesture that "arms"
+    // the release, and an actual change in the vertical scroll offset. Requiring
+    // both means the programmatic smooth scroll (no gesture) and horizontal nav
+    // swipes (no vertical change) leave the lock intact, while a real vertical
+    // scroll by the user hands control back to the scroll spy.
+    armedRef.current = false
+    let lastScroll = getVerticalScroll()
+
+    const onScroll = () => {
+      const current = getVerticalScroll()
+      if (lockedRef.current && armedRef.current && current !== lastScroll) {
+        lockedRef.current = false
+        armedRef.current = false
+      }
+      lastScroll = current
+      // Fallback for the "scrolled past the observer's active band" case for
+      // short final sections that never trip the intersection.
+      pickActive()
+    }
     window.addEventListener('scroll', onScroll, { passive: true, capture: true })
 
-    // A genuine user-initiated scroll releases the click lock so the scroll spy
-    // resumes tracking the real scroll position.
-    const releaseLock = () => {
-      if (lockedRef.current) {
-        lockedRef.current = false
-        pickActive()
-      }
+    const arm = () => {
+      armedRef.current = true
     }
     const onKeyDown = (event: KeyboardEvent) => {
-      if (SCROLL_KEYS.has(event.key)) {
-        releaseLock()
+      if (!isEditableTarget(event.target) && SCROLL_KEYS.has(event.key)) {
+        armedRef.current = true
       }
     }
-    window.addEventListener('wheel', releaseLock, { passive: true, capture: true })
-    window.addEventListener('touchmove', releaseLock, { passive: true, capture: true })
+    window.addEventListener('wheel', arm, { passive: true, capture: true })
+    window.addEventListener('touchmove', arm, { passive: true, capture: true })
     window.addEventListener('keydown', onKeyDown, { passive: true, capture: true })
 
     return () => {
       observer.disconnect()
       window.removeEventListener('scroll', onScroll, true)
-      window.removeEventListener('wheel', releaseLock, true)
-      window.removeEventListener('touchmove', releaseLock, true)
+      window.removeEventListener('wheel', arm, true)
+      window.removeEventListener('touchmove', arm, true)
       window.removeEventListener('keydown', onKeyDown, true)
     }
     // eslint-disable-next-line @eslint-react/exhaustive-deps -- `key` (joined ids) captures the array identity

--- a/client/src/thesis/pages/ThesisPage/hooks/useActiveSection.ts
+++ b/client/src/thesis/pages/ThesisPage/hooks/useActiveSection.ts
@@ -146,7 +146,10 @@ export function useActiveSection(
     // the release, and an actual change in the vertical scroll offset. Requiring
     // both means the programmatic smooth scroll (no gesture) and horizontal nav
     // swipes (no vertical change) leave the lock intact, while a real vertical
-    // scroll by the user hands control back to the scroll spy.
+    // scroll by the user hands control back to the scroll spy. Arming is safe to
+    // do generously (release still needs the offset to move), so `pointerdown`
+    // covers dragging the window's or the ancestor's vertical scrollbar — which
+    // fires none of the other gestures.
     armedRef.current = false
     let lastScroll = getVerticalScroll()
 
@@ -173,6 +176,7 @@ export function useActiveSection(
     }
     window.addEventListener('wheel', arm, { passive: true, capture: true })
     window.addEventListener('touchmove', arm, { passive: true, capture: true })
+    window.addEventListener('pointerdown', arm, { passive: true, capture: true })
     window.addEventListener('keydown', onKeyDown, { passive: true, capture: true })
 
     return () => {
@@ -180,6 +184,7 @@ export function useActiveSection(
       window.removeEventListener('scroll', onScroll, true)
       window.removeEventListener('wheel', arm, true)
       window.removeEventListener('touchmove', arm, true)
+      window.removeEventListener('pointerdown', arm, true)
       window.removeEventListener('keydown', onKeyDown, true)
     }
     // eslint-disable-next-line @eslint-react/exhaustive-deps -- `key` (joined ids) captures the array identity

--- a/client/src/thesis/pages/ThesisPage/hooks/useActiveSection.ts
+++ b/client/src/thesis/pages/ThesisPage/hooks/useActiveSection.ts
@@ -85,19 +85,18 @@ export function useActiveSection(
     const getVerticalScroll = () => window.scrollY + (scrollAncestor?.scrollTop ?? 0)
 
     const isScrolledToBottom = () => {
-      // Handles both window scrolling and any scrollable ancestor with fixed height.
-      const doc = document.documentElement
-      const winBottom = Math.ceil(window.innerHeight + window.scrollY) >= doc.scrollHeight - 2
-      if (winBottom) {
-        return true
-      }
+      // When an ancestor is the scroll container, the window itself usually
+      // doesn't overflow, so its bottom check reads as permanently true — check
+      // the ancestor exclusively and only fall back to the window when there's
+      // no scroll ancestor.
       if (scrollAncestor) {
         return (
           Math.ceil(scrollAncestor.scrollTop + scrollAncestor.clientHeight) >=
           scrollAncestor.scrollHeight - 2
         )
       }
-      return false
+      const doc = document.documentElement
+      return Math.ceil(window.innerHeight + window.scrollY) >= doc.scrollHeight - 2
     }
 
     const pickActive = () => {


### PR DESCRIPTION
## Problem

On the redesigned thesis overview page (#1190), clicking a step in the sticky process nav scrolls to that section but the highlighted ("active") pill often snaps back to **Overview**.

Cause: the active highlight is driven entirely by the scroll spy, which highlights the topmost visible section. When the sections above the target are collapsed/short, `scrollIntoView` can't bring the target all the way to the top (not enough content below it), so Overview stays at the top of the viewport and keeps the highlight — even though the user clicked, e.g., **Thesis**. A click had no way to assert the active section itself.

## Fix

`useActiveSection` now returns `[activeId, setActiveSection]`. On click, the nav:

1. Calls `setActiveSection(id)` to highlight the clicked section immediately, and
2. **Locks** the scroll spy so its `IntersectionObserver`/scroll re-evaluation can't override the choice.

The lock releases on the next user-initiated scroll (`wheel`, `touchmove`, or a scroll key — arrows/PageUp-Down/Home/End/Space), after which scroll-spy tracking resumes exactly as before. Plain typing in inputs is ignored so the lock doesn't drop unexpectedly.

Net effect: clicking a nav step highlights that step and keeps it highlighted until the user scrolls away, matching intent regardless of how far the page can actually scroll.

## Testing

- `pnpm exec tsc --noEmit` — clean
- `pnpm exec eslint` on both changed files — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved thesis section navigation so the selected step is highlighted immediately when clicked.
  * Prevented scroll-based navigation updates from overriding the user’s selection until users resume scrolling or use touch, pointer, wheel, or keyboard navigation.
  * Improved active-section tracking within scrollable areas, including at their boundaries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->