### PR TITLE
Add per-category counts, addressed progress, and an AI review score

### DIFF
--- a/client/src/thesis/pages/ThesisPage/components/ThesisFeedbackOverview/ThesisFeedbackOverview.summary.test.tsx
+++ b/client/src/thesis/pages/ThesisPage/components/ThesisFeedbackOverview/ThesisFeedbackOverview.summary.test.tsx
@@ -18,6 +18,7 @@ const requestedBy = {
 // Newest-first, matching the server's ordering.
 let proposals = [{ proposalId: 'proposal-v1' }]
 let aiReviewSummaries: Array<Record<string, unknown>> = []
+let feedback: Array<Record<string, unknown>> = []
 
 vi.mock('@/thesis/providers/ThesisProvider/hooks', () => ({
   useLoadedThesisContext: () => ({
@@ -25,17 +26,7 @@ vi.mock('@/thesis/providers/ThesisProvider/hooks', () => ({
       thesisId: 'thesis-1',
       proposals,
       aiReviewSummaries,
-      feedback: [
-        {
-          feedbackId: 'fb-1',
-          type: 'PROPOSAL',
-          feedback: 'Tighten the introduction.',
-          requestedBy,
-          requestedAt: '2026-04-01T10:00:00Z',
-          completedAt: null,
-          documentVersionId: 'proposal-v1',
-        },
-      ],
+      feedback,
     },
     access: { student: false, supervisor: true, examiner: false },
     updateThesis: vi.fn(),
@@ -46,6 +37,17 @@ vi.mock('@/thesis/providers/ThesisProvider/hooks', () => ({
 describe('ThesisFeedbackOverview — AI review summary staleness', () => {
   beforeEach(() => {
     proposals = [{ proposalId: 'proposal-v1' }]
+    feedback = [
+      {
+        feedbackId: 'fb-1',
+        type: 'PROPOSAL',
+        feedback: 'Tighten the introduction.',
+        requestedBy,
+        requestedAt: '2026-04-01T10:00:00Z',
+        completedAt: null,
+        documentVersionId: 'proposal-v1',
+      },
+    ]
     aiReviewSummaries = [
       {
         type: 'PROPOSAL',
@@ -74,6 +76,30 @@ describe('ThesisFeedbackOverview — AI review summary staleness', () => {
     expect(screen.queryByText('Solid proposal.')).not.toBeInTheDocument()
     // The feedback table itself still renders — only the summary is version-scoped.
     expect(screen.getByText('Tighten the introduction.')).toBeInTheDocument()
+  })
+
+  test('still shows the summary when the review found nothing to flag', () => {
+    // An AI review with no actionable findings saves a summary and no feedback rows at all.
+    feedback = []
+
+    renderWithProviders(<ThesisFeedbackOverview type='PROPOSAL' allowEdit />)
+
+    expect(screen.getByText(/overall score: 82\/100/i)).toBeInTheDocument()
+    expect(screen.getByText('Solid proposal.')).toBeInTheDocument()
+    // Nothing to count or filter, so the table chrome stays away.
+    expect(screen.queryByPlaceholderText(/search feedback/i)).not.toBeInTheDocument()
+    expect(screen.queryByText(/addressed/i)).not.toBeInTheDocument()
+  })
+
+  test('renders nothing when there is neither feedback nor a current summary', () => {
+    feedback = []
+    aiReviewSummaries = []
+
+    renderWithProviders(<ThesisFeedbackOverview type='PROPOSAL' allowEdit />)
+
+    // renderWithProviders injects Mantine's style tags, so assert on the section itself.
+    expect(screen.queryByText('Feedback')).not.toBeInTheDocument()
+    expect(screen.queryByText(/overall score/i)).not.toBeInTheDocument()
   })
 
   test('hides a legacy summary that carries no document version', () => {

--- a/client/src/thesis/pages/ThesisPage/components/ThesisFeedbackOverview/ThesisFeedbackOverview.summary.test.tsx
+++ b/client/src/thesis/pages/ThesisPage/components/ThesisFeedbackOverview/ThesisFeedbackOverview.summary.test.tsx
@@ -65,6 +65,9 @@ describe('ThesisFeedbackOverview — AI review summary staleness', () => {
 
     expect(screen.getByText(/overall score: 82\/100/i)).toBeInTheDocument()
     expect(screen.getByText('Solid proposal.')).toBeInTheDocument()
+    // Dated and version-labelled, so it does not read as a live verdict on the whole list. The
+    // date itself is locale-formatted, hence only the stable prefix is asserted.
+    expect(screen.getByText(/^AI review of v1 · /)).toBeInTheDocument()
   })
 
   test('hides the summary once a newer proposal has been uploaded', () => {

--- a/client/src/thesis/pages/ThesisPage/components/ThesisFeedbackOverview/ThesisFeedbackOverview.summary.test.tsx
+++ b/client/src/thesis/pages/ThesisPage/components/ThesisFeedbackOverview/ThesisFeedbackOverview.summary.test.tsx
@@ -1,0 +1,94 @@
+import { describe, expect, test, vi, beforeEach } from 'vitest'
+import { renderWithProviders, screen } from '@/../test/render'
+import ThesisFeedbackOverview from '@/thesis/pages/ThesisPage/components/ThesisFeedbackOverview/ThesisFeedbackOverview'
+
+// An AI review summary describes one specific revision of the proposal/thesis document. Once a
+// newer document is uploaded the persisted summary is about the superseded one, so it must not
+// keep presenting its score as the current assessment.
+
+const requestedBy = {
+  userId: 'u1',
+  universityId: 'u1',
+  firstName: 'Ada',
+  lastName: 'Lovelace',
+  email: 'ada@example.com',
+  avatar: false,
+}
+
+// Newest-first, matching the server's ordering.
+let proposals = [{ proposalId: 'proposal-v1' }]
+let aiReviewSummaries: Array<Record<string, unknown>> = []
+
+vi.mock('@/thesis/providers/ThesisProvider/hooks', () => ({
+  useLoadedThesisContext: () => ({
+    thesis: {
+      thesisId: 'thesis-1',
+      proposals,
+      aiReviewSummaries,
+      feedback: [
+        {
+          feedbackId: 'fb-1',
+          type: 'PROPOSAL',
+          feedback: 'Tighten the introduction.',
+          requestedBy,
+          requestedAt: '2026-04-01T10:00:00Z',
+          completedAt: null,
+          documentVersionId: 'proposal-v1',
+        },
+      ],
+    },
+    access: { student: false, supervisor: true, examiner: false },
+    updateThesis: vi.fn(),
+  }),
+  useThesisUpdateAction: () => [false, vi.fn()],
+}))
+
+describe('ThesisFeedbackOverview — AI review summary staleness', () => {
+  beforeEach(() => {
+    proposals = [{ proposalId: 'proposal-v1' }]
+    aiReviewSummaries = [
+      {
+        type: 'PROPOSAL',
+        score: 82,
+        assessment: 'GOOD',
+        summary: 'Solid proposal.',
+        documentVersionId: 'proposal-v1',
+        updatedAt: '2026-04-01T10:00:00Z',
+      },
+    ]
+  })
+
+  test('shows the summary while it matches the latest proposal', () => {
+    renderWithProviders(<ThesisFeedbackOverview type='PROPOSAL' allowEdit />)
+
+    expect(screen.getByText(/overall score: 82\/100/i)).toBeInTheDocument()
+    expect(screen.getByText('Solid proposal.')).toBeInTheDocument()
+  })
+
+  test('hides the summary once a newer proposal has been uploaded', () => {
+    proposals = [{ proposalId: 'proposal-v2' }, { proposalId: 'proposal-v1' }]
+
+    renderWithProviders(<ThesisFeedbackOverview type='PROPOSAL' allowEdit />)
+
+    expect(screen.queryByText(/overall score/i)).not.toBeInTheDocument()
+    expect(screen.queryByText('Solid proposal.')).not.toBeInTheDocument()
+    // The feedback table itself still renders — only the summary is version-scoped.
+    expect(screen.getByText('Tighten the introduction.')).toBeInTheDocument()
+  })
+
+  test('hides a legacy summary that carries no document version', () => {
+    aiReviewSummaries = [
+      {
+        type: 'PROPOSAL',
+        score: 82,
+        assessment: 'GOOD',
+        summary: 'Solid proposal.',
+        updatedAt: '2026-04-01T10:00:00Z',
+      },
+    ]
+
+    renderWithProviders(<ThesisFeedbackOverview type='PROPOSAL' allowEdit />)
+
+    expect(screen.queryByText(/overall score/i)).not.toBeInTheDocument()
+  })
+})

--- a/client/src/thesis/pages/ThesisPage/components/ThesisFeedbackOverview/ThesisFeedbackOverview.tsx
+++ b/client/src/thesis/pages/ThesisPage/components/ThesisFeedbackOverview/ThesisFeedbackOverview.tsx
@@ -3,24 +3,23 @@ import {
   useThesisUpdateAction,
 } from '@/thesis/providers/ThesisProvider/hooks'
 import {
+  Alert,
   Badge,
   Center,
   Checkbox,
   Group,
   Input,
   Pagination,
+  Progress,
   Select,
   Stack,
   Table,
   Text,
   TextInput,
+  Tooltip,
 } from '@mantine/core'
 import type { IThesis } from '@/thesis/requests/responses/thesis'
-import {
-  ThesisFeedbackCategory,
-  ThesisFeedbackSeverity,
-  ThesisFeedbackSource,
-} from '@/thesis/requests/responses/thesis'
+import { ThesisFeedbackCategory, ThesisFeedbackSource } from '@/thesis/requests/responses/thesis'
 import React from 'react'
 import AvatarUser from '@/core/components/AvatarUser/AvatarUser'
 import { formatDate } from '@/core/utils/format'
@@ -28,6 +27,17 @@ import { doRequest } from '@/core/requests/request'
 import { ApiError } from '@/core/requests/handler'
 import { MagnifyingGlass, Trash } from '@phosphor-icons/react'
 import ConfirmationButton from '@/core/components/ConfirmationButton/ConfirmationButton'
+import {
+  ASSESSMENT_COLOR,
+  ASSESSMENT_LABEL,
+  CATEGORY_DESCRIPTION,
+  humanizeFeedbackCategory,
+  SEVERITY_COLOR,
+  SEVERITY_DESCRIPTION,
+  SOURCE_COLOR,
+  SOURCE_DESCRIPTION,
+  SOURCE_LABEL,
+} from '@/thesis/utils/feedbackLabels'
 
 const PAGE_SIZE = 10
 
@@ -36,32 +46,6 @@ type ResolvedFilter = 'ALL' | 'OPEN' | 'RESOLVED'
 interface IThesisFeedbackOverviewProps {
   type: string
   allowEdit: boolean
-}
-
-const SEVERITY_COLOR: Record<ThesisFeedbackSeverity, string> = {
-  [ThesisFeedbackSeverity.CRITICAL]: 'red',
-  [ThesisFeedbackSeverity.MAJOR]: 'orange',
-  [ThesisFeedbackSeverity.MINOR]: 'yellow',
-  [ThesisFeedbackSeverity.SUGGESTION]: 'blue',
-}
-
-const SOURCE_LABEL: Record<ThesisFeedbackSource, string> = {
-  [ThesisFeedbackSource.AI]: 'AI',
-  [ThesisFeedbackSource.HUMAN]: 'Instructor',
-  [ThesisFeedbackSource.AI_REVIEWED_BY_HUMAN]: 'AI + Instructor',
-}
-
-const SOURCE_COLOR: Record<ThesisFeedbackSource, string> = {
-  [ThesisFeedbackSource.AI]: 'grape',
-  [ThesisFeedbackSource.HUMAN]: 'gray',
-  [ThesisFeedbackSource.AI_REVIEWED_BY_HUMAN]: 'teal',
-}
-
-const humanizeCategory = (value: ThesisFeedbackCategory | string | null | undefined): string => {
-  if (!value) return ''
-  return String(value)
-    .toLowerCase()
-    .replace(/(^\w|_\w)/g, (m) => m.replace('_', ' ').toUpperCase())
 }
 
 /**
@@ -137,6 +121,25 @@ const ThesisFeedbackOverview = (props: IThesisFeedbackOverviewProps) => {
     [thesis.feedback, type],
   )
 
+  const reviewSummary = React.useMemo(
+    () => (thesis.aiReviewSummaries ?? []).find((summary) => summary.type === type),
+    [thesis.aiReviewSummaries, type],
+  )
+
+  const categoryCounts = React.useMemo(() => {
+    const counts = new Map<ThesisFeedbackCategory, number>()
+    feedbackForType.forEach((item) => {
+      if (!item.category) return
+      counts.set(item.category, (counts.get(item.category) ?? 0) + 1)
+    })
+    return counts
+  }, [feedbackForType])
+
+  const addressedCount = React.useMemo(
+    () => feedbackForType.filter((item) => item.completedAt).length,
+    [feedbackForType],
+  )
+
   const [search, setSearch] = React.useState('')
   const [categoryFilter, setCategoryFilter] = React.useState<string | null>(null)
   const [resolvedFilter, setResolvedFilter] = React.useState<ResolvedFilter>('ALL')
@@ -175,12 +178,74 @@ const ThesisFeedbackOverview = (props: IThesisFeedbackOverviewProps) => {
 
   const categoryOptions = Object.values(ThesisFeedbackCategory).map((value) => ({
     value,
-    label: humanizeCategory(value),
+    label: humanizeFeedbackCategory(value),
   }))
 
   return (
     <Input.Wrapper label='Feedback'>
       <Stack gap='sm'>
+        {reviewSummary &&
+          (Boolean(reviewSummary.summary) || typeof reviewSummary.score === 'number') && (
+            <Alert
+              color={reviewSummary.assessment ? ASSESSMENT_COLOR[reviewSummary.assessment] : 'gray'}
+              variant='light'
+              title={
+                typeof reviewSummary.score === 'number'
+                  ? `Overall Score: ${reviewSummary.score}/100`
+                  : 'AI review summary'
+              }
+            >
+              <Stack gap={4}>
+                {reviewSummary.assessment && (
+                  <Text size='sm' fw={500}>
+                    {ASSESSMENT_LABEL[reviewSummary.assessment]}
+                  </Text>
+                )}
+                {reviewSummary.summary && (
+                  <Text size='sm' c='dimmed'>
+                    {reviewSummary.summary}
+                  </Text>
+                )}
+              </Stack>
+            </Alert>
+          )}
+        <Group gap='lg' align='center' wrap='wrap'>
+          <Group gap={6} align='center'>
+            <Text size='sm' fw={500}>
+              {addressedCount}/{feedbackForType.length} addressed
+            </Text>
+            <Progress.Root size={8} radius='xl' style={{ width: 120 }}>
+              <Progress.Section
+                value={feedbackForType.length ? (addressedCount / feedbackForType.length) * 100 : 0}
+                color='green'
+              />
+              <Progress.Section
+                value={
+                  feedbackForType.length
+                    ? ((feedbackForType.length - addressedCount) / feedbackForType.length) * 100
+                    : 0
+                }
+                color='gray.3'
+              />
+            </Progress.Root>
+          </Group>
+          {categoryCounts.size > 0 && (
+            <Group gap={6}>
+              {Array.from(categoryCounts.entries()).map(([category, count]) => (
+                <Tooltip
+                  key={category}
+                  label={CATEGORY_DESCRIPTION[category]}
+                  withArrow
+                  openDelay={300}
+                >
+                  <Badge size='sm' color='gray' variant='outline'>
+                    {humanizeFeedbackCategory(category)}: {count}
+                  </Badge>
+                </Tooltip>
+              ))}
+            </Group>
+          )}
+        </Group>
         <Group gap='sm' align='flex-end' wrap='wrap'>
           <TextInput
             style={{ flex: 1, minWidth: 200 }}
@@ -241,27 +306,55 @@ const ThesisFeedbackOverview = (props: IThesisFeedbackOverviewProps) => {
                   </Table.Td>
                   <Table.Td>
                     <Stack gap={4}>
-                      <Text>{item.feedback}</Text>
+                      <Text
+                        td={item.completedAt ? 'line-through' : undefined}
+                        c={item.completedAt ? 'dimmed' : undefined}
+                      >
+                        {item.feedback}
+                      </Text>
                       <Group gap={4}>
-                        {item.severity && (
-                          <Badge size='sm' color={SEVERITY_COLOR[item.severity]} variant='light'>
-                            {item.severity}
+                        {item.completedAt && (
+                          <Badge size='sm' color='green' variant='light'>
+                            Addressed
                           </Badge>
                         )}
+                        {item.severity && (
+                          <Tooltip
+                            label={SEVERITY_DESCRIPTION[item.severity]}
+                            withArrow
+                            openDelay={300}
+                          >
+                            <Badge size='sm' color={SEVERITY_COLOR[item.severity]} variant='light'>
+                              {item.severity}
+                            </Badge>
+                          </Tooltip>
+                        )}
                         {item.category && (
-                          <Badge size='sm' color='gray' variant='outline'>
-                            {humanizeCategory(item.category)}
-                          </Badge>
+                          <Tooltip
+                            label={CATEGORY_DESCRIPTION[item.category]}
+                            withArrow
+                            openDelay={300}
+                          >
+                            <Badge size='sm' color='gray' variant='outline'>
+                              {humanizeFeedbackCategory(item.category)}
+                            </Badge>
+                          </Tooltip>
                         )}
                         {item.generationSource &&
                           item.generationSource !== ThesisFeedbackSource.HUMAN && (
-                            <Badge
-                              size='sm'
-                              color={SOURCE_COLOR[item.generationSource]}
-                              variant='light'
+                            <Tooltip
+                              label={SOURCE_DESCRIPTION[item.generationSource]}
+                              withArrow
+                              openDelay={300}
                             >
-                              {SOURCE_LABEL[item.generationSource]}
-                            </Badge>
+                              <Badge
+                                size='sm'
+                                color={SOURCE_COLOR[item.generationSource]}
+                                variant='light'
+                              >
+                                {SOURCE_LABEL[item.generationSource]}
+                              </Badge>
+                            </Tooltip>
                           )}
                         {item.documentVersionId && versionLabelById.get(item.documentVersionId) && (
                           <Badge size='sm' color='blue' variant='outline'>

--- a/client/src/thesis/pages/ThesisPage/components/ThesisFeedbackOverview/ThesisFeedbackOverview.tsx
+++ b/client/src/thesis/pages/ThesisPage/components/ThesisFeedbackOverview/ThesisFeedbackOverview.tsx
@@ -205,6 +205,19 @@ const ThesisFeedbackOverview = (props: IThesisFeedbackOverviewProps) => {
   const clampedPage = Math.min(page, totalPages)
   const visibleItems = filteredItems.slice((clampedPage - 1) * PAGE_SIZE, clampedPage * PAGE_SIZE)
 
+  // Say where the score came from. It is the AI's read of one specific revision at one point in
+  // time, not a live verdict on the feedback list it sits above — supervisors keep adding entries
+  // afterwards without the score moving, so the alert has to date itself.
+  const summaryVersionLabel = reviewSummary?.documentVersionId
+    ? versionLabelById.get(reviewSummary.documentVersionId)
+    : undefined
+  const summaryProvenance = [
+    summaryVersionLabel ? `AI review of ${summaryVersionLabel}` : 'AI review',
+    reviewSummary?.updatedAt ? formatDate(reviewSummary.updatedAt, { withTime: false }) : '',
+  ]
+    .filter(Boolean)
+    .join(' · ')
+
   const summaryAlert =
     reviewSummary && (Boolean(reviewSummary.summary) || typeof reviewSummary.score === 'number') ? (
       <Alert
@@ -227,6 +240,9 @@ const ThesisFeedbackOverview = (props: IThesisFeedbackOverviewProps) => {
               {reviewSummary.summary}
             </Text>
           )}
+          <Text size='xs' c='dimmed'>
+            {summaryProvenance}
+          </Text>
         </Stack>
       </Alert>
     ) : null

--- a/client/src/thesis/pages/ThesisPage/components/ThesisFeedbackOverview/ThesisFeedbackOverview.tsx
+++ b/client/src/thesis/pages/ThesisPage/components/ThesisFeedbackOverview/ThesisFeedbackOverview.tsx
@@ -69,6 +69,24 @@ const buildVersionLabelMap = (
   return map
 }
 
+/**
+ * The id of the newest revision of the document this feedback section is about — the current
+ * proposal for PROPOSAL, the current thesis file for THESIS. Both lists are newest-first.
+ */
+const resolveLatestVersionId = (
+  type: string,
+  proposals: IThesis['proposals'] | undefined,
+  files: IThesis['files'] | undefined,
+): string | undefined => {
+  if (type === 'PROPOSAL') {
+    return (proposals ?? [])[0]?.proposalId
+  }
+  if (type === 'THESIS') {
+    return (files ?? []).find((file) => file.type === 'THESIS')?.fileId
+  }
+  return undefined
+}
+
 const ThesisFeedbackOverview = (props: IThesisFeedbackOverviewProps) => {
   const { type, allowEdit } = props
 
@@ -121,9 +139,24 @@ const ThesisFeedbackOverview = (props: IThesisFeedbackOverviewProps) => {
     [thesis.feedback, type],
   )
 
+  const latestVersionId = React.useMemo(
+    () => resolveLatestVersionId(type, thesis.proposals, thesis.files),
+    [type, thesis.proposals, thesis.files],
+  )
+
+  // A summary describes one specific revision, so it only stands for the document currently on
+  // screen. Once a newer proposal or thesis file is uploaded (or for legacy rows that predate
+  // the version column and cannot be placed), drop it rather than passing off an obsolete score
+  // as the current one — the next AI review writes a summary for the new revision.
   const reviewSummary = React.useMemo(
-    () => (thesis.aiReviewSummaries ?? []).find((summary) => summary.type === type),
-    [thesis.aiReviewSummaries, type],
+    () =>
+      (thesis.aiReviewSummaries ?? []).find(
+        (summary) =>
+          summary.type === type &&
+          Boolean(latestVersionId) &&
+          summary.documentVersionId === latestVersionId,
+      ),
+    [thesis.aiReviewSummaries, type, latestVersionId],
   )
 
   const categoryCounts = React.useMemo(() => {

--- a/client/src/thesis/pages/ThesisPage/components/ThesisFeedbackOverview/ThesisFeedbackOverview.tsx
+++ b/client/src/thesis/pages/ThesisPage/components/ThesisFeedbackOverview/ThesisFeedbackOverview.tsx
@@ -205,8 +205,36 @@ const ThesisFeedbackOverview = (props: IThesisFeedbackOverviewProps) => {
   const clampedPage = Math.min(page, totalPages)
   const visibleItems = filteredItems.slice((clampedPage - 1) * PAGE_SIZE, clampedPage * PAGE_SIZE)
 
+  const summaryAlert =
+    reviewSummary && (Boolean(reviewSummary.summary) || typeof reviewSummary.score === 'number') ? (
+      <Alert
+        color={reviewSummary.assessment ? ASSESSMENT_COLOR[reviewSummary.assessment] : 'gray'}
+        variant='light'
+        title={
+          typeof reviewSummary.score === 'number'
+            ? `Overall Score: ${reviewSummary.score}/100`
+            : 'AI review summary'
+        }
+      >
+        <Stack gap={4}>
+          {reviewSummary.assessment && (
+            <Text size='sm' fw={500}>
+              {ASSESSMENT_LABEL[reviewSummary.assessment]}
+            </Text>
+          )}
+          {reviewSummary.summary && (
+            <Text size='sm' c='dimmed'>
+              {reviewSummary.summary}
+            </Text>
+          )}
+        </Stack>
+      </Alert>
+    ) : null
+
+  // A review that flags nothing still records a score, so an empty feedback list does not mean
+  // there is nothing to show — just nothing to count, filter, or tabulate.
   if (feedbackForType.length === 0) {
-    return null
+    return summaryAlert ? <Input.Wrapper label='Feedback'>{summaryAlert}</Input.Wrapper> : null
   }
 
   const categoryOptions = Object.values(ThesisFeedbackCategory).map((value) => ({
@@ -217,31 +245,7 @@ const ThesisFeedbackOverview = (props: IThesisFeedbackOverviewProps) => {
   return (
     <Input.Wrapper label='Feedback'>
       <Stack gap='sm'>
-        {reviewSummary &&
-          (Boolean(reviewSummary.summary) || typeof reviewSummary.score === 'number') && (
-            <Alert
-              color={reviewSummary.assessment ? ASSESSMENT_COLOR[reviewSummary.assessment] : 'gray'}
-              variant='light'
-              title={
-                typeof reviewSummary.score === 'number'
-                  ? `Overall Score: ${reviewSummary.score}/100`
-                  : 'AI review summary'
-              }
-            >
-              <Stack gap={4}>
-                {reviewSummary.assessment && (
-                  <Text size='sm' fw={500}>
-                    {ASSESSMENT_LABEL[reviewSummary.assessment]}
-                  </Text>
-                )}
-                {reviewSummary.summary && (
-                  <Text size='sm' c='dimmed'>
-                    {reviewSummary.summary}
-                  </Text>
-                )}
-              </Stack>
-            </Alert>
-          )}
+        {summaryAlert}
         <Group gap='lg' align='center' wrap='wrap'>
           <Group gap={6} align='center'>
             <Text size='sm' fw={500}>

--- a/client/src/thesis/pages/ThesisPage/components/ThesisFeedbackRequestButton/ThesisFeedbackRequestButton.tsx
+++ b/client/src/thesis/pages/ThesisPage/components/ThesisFeedbackRequestButton/ThesisFeedbackRequestButton.tsx
@@ -117,12 +117,12 @@ const ThesisFeedbackRequestButton = (props: IThesisFeedbackRequestButtonProps) =
 
   const categoryCounts = useMemo(() => {
     const counts = new Map<ThesisFeedbackCategory, number>()
-    validEntries.forEach((entry) => {
-      if (!entry.category) return
-      counts.set(entry.category, (counts.get(entry.category) ?? 0) + 1)
+    ;(aiAssessment?.drafts ?? []).forEach((draft) => {
+      if (!draft.category) return
+      counts.set(draft.category, (counts.get(draft.category) ?? 0) + 1)
     })
     return counts
-  }, [validEntries])
+  }, [aiAssessment])
 
   const hasUnsavedWork = validEntries.length > 0 || editChanges.length > 0
 

--- a/client/src/thesis/pages/ThesisPage/components/ThesisFeedbackRequestButton/ThesisFeedbackRequestButton.tsx
+++ b/client/src/thesis/pages/ThesisPage/components/ThesisFeedbackRequestButton/ThesisFeedbackRequestButton.tsx
@@ -30,6 +30,14 @@ import { ApiError, getApiResponseErrorMessage } from '@/core/requests/handler'
 import { Plus, Robot, Trash } from '@phosphor-icons/react'
 import { showSimpleError } from '@/core/utils/notification'
 import { GLOBAL_CONFIG } from '@/core/config/global'
+import {
+  ASSESSMENT_LABEL,
+  CATEGORY_DESCRIPTION,
+  humanizeFeedbackCategory,
+  SEVERITY_COLOR,
+  SEVERITY_DESCRIPTION,
+} from '@/thesis/utils/feedbackLabels'
+import type { AIAssessment } from '@/thesis/utils/feedbackLabels'
 
 interface IThesisFeedbackRequestButtonProps {
   type: string
@@ -53,33 +61,21 @@ interface IAIDraft {
 }
 
 interface IAIPreviewResponse {
-  assessment?: 'GOOD' | 'ACCEPTABLE' | 'NEEDS_WORK'
+  assessment?: AIAssessment
+  score?: number | null
   summary?: string
   drafts?: IAIDraft[]
 }
 
 const CATEGORY_OPTIONS = Object.values(ThesisFeedbackCategory).map((value) => ({
   value,
-  label: value.toLowerCase().replace(/(^\w|_\w)/g, (m) => m.replace('_', ' ').toUpperCase()),
+  label: humanizeFeedbackCategory(value),
 }))
 
 const SEVERITY_OPTIONS = Object.values(ThesisFeedbackSeverity).map((value) => ({
   value,
   label: value.charAt(0) + value.slice(1).toLowerCase(),
 }))
-
-const SEVERITY_COLOR: Record<ThesisFeedbackSeverity, string> = {
-  [ThesisFeedbackSeverity.CRITICAL]: 'red',
-  [ThesisFeedbackSeverity.MAJOR]: 'orange',
-  [ThesisFeedbackSeverity.MINOR]: 'yellow',
-  [ThesisFeedbackSeverity.SUGGESTION]: 'blue',
-}
-
-const ASSESSMENT_LABEL: Record<NonNullable<IAIPreviewResponse['assessment']>, string> = {
-  GOOD: 'Good — ready to submit with minor tweaks',
-  ACCEPTABLE: 'Acceptable — some work needed',
-  NEEDS_WORK: 'Needs work — significant issues remain',
-}
 
 const emptyEntry = (): INewEntry => ({
   key: crypto.randomUUID(),
@@ -118,6 +114,15 @@ const ThesisFeedbackRequestButton = (props: IThesisFeedbackRequestButtonProps) =
     () => entries.filter((entry) => entry.feedback.trim().length > 0),
     [entries],
   )
+
+  const categoryCounts = useMemo(() => {
+    const counts = new Map<ThesisFeedbackCategory, number>()
+    validEntries.forEach((entry) => {
+      if (!entry.category) return
+      counts.set(entry.category, (counts.get(entry.category) ?? 0) + 1)
+    })
+    return counts
+  }, [validEntries])
 
   const hasUnsavedWork = validEntries.length > 0 || editChanges.length > 0
 
@@ -295,7 +300,15 @@ const ThesisFeedbackRequestButton = (props: IThesisFeedbackRequestButtonProps) =
             <Divider label='New feedback entries' labelPosition='left' />
 
             {aiAssessment && (
-              <Alert color='grape' variant='light' title='AI review'>
+              <Alert
+                color='grape'
+                variant='light'
+                title={
+                  typeof aiAssessment.score === 'number'
+                    ? `AI review — Overall Score: ${aiAssessment.score}/100`
+                    : 'AI review'
+                }
+              >
                 <Stack gap={4}>
                   {aiAssessment.assessment && (
                     <Text size='sm' fw={500}>
@@ -306,6 +319,22 @@ const ThesisFeedbackRequestButton = (props: IThesisFeedbackRequestButtonProps) =
                     <Text size='sm' c='dimmed'>
                       {aiAssessment.summary}
                     </Text>
+                  )}
+                  {categoryCounts.size > 0 && (
+                    <Group gap={6}>
+                      {Array.from(categoryCounts.entries()).map(([category, count]) => (
+                        <Tooltip
+                          key={category}
+                          label={CATEGORY_DESCRIPTION[category]}
+                          withArrow
+                          openDelay={300}
+                        >
+                          <Badge size='sm' color='gray' variant='outline'>
+                            {humanizeFeedbackCategory(category)}: {count}
+                          </Badge>
+                        </Tooltip>
+                      ))}
+                    </Group>
                   )}
                   <Text size='xs' c='dimmed'>
                     Entries below are drafts — edit or delete them before saving.
@@ -328,9 +357,15 @@ const ThesisFeedbackRequestButton = (props: IThesisFeedbackRequestButtonProps) =
                         Entry {index + 1}
                       </Text>
                       {entry.severity && (
-                        <Badge size='sm' color={SEVERITY_COLOR[entry.severity]} variant='light'>
-                          {entry.severity}
-                        </Badge>
+                        <Tooltip
+                          label={SEVERITY_DESCRIPTION[entry.severity]}
+                          withArrow
+                          openDelay={300}
+                        >
+                          <Badge size='sm' color={SEVERITY_COLOR[entry.severity]} variant='light'>
+                            {entry.severity}
+                          </Badge>
+                        </Tooltip>
                       )}
                     </Group>
                     <Tooltip label='Remove entry'>

--- a/client/src/thesis/requests/responses/thesis.ts
+++ b/client/src/thesis/requests/responses/thesis.ts
@@ -145,6 +145,16 @@ export interface IThesis extends IThesisOverview {
     // client resolves it to a "v{n}" label by matching against thesis.proposals / thesis.files.
     documentVersionId?: string | null
   }>
+  // The AI review pipeline's latest read on the proposal/thesis document — persisted on every
+  // review run (student auto-review or supervisor preview), independent of which findings (if
+  // any) were saved.
+  aiReviewSummaries?: Array<{
+    type: 'PROPOSAL' | 'THESIS'
+    score?: number | null
+    assessment?: 'GOOD' | 'ACCEPTABLE' | 'NEEDS_WORK' | null
+    summary?: string | null
+    updatedAt: string
+  }>
   grade: null | {
     finalGrade: string
     feedback: string

--- a/client/src/thesis/requests/responses/thesis.ts
+++ b/client/src/thesis/requests/responses/thesis.ts
@@ -146,13 +146,15 @@ export interface IThesis extends IThesisOverview {
     documentVersionId?: string | null
   }>
   // The AI review pipeline's latest read on the proposal/thesis document — persisted on every
-  // review run (student auto-review or supervisor preview), independent of which findings (if
-  // any) were saved.
+  // auto-review run, independent of which findings (if any) were saved.
   aiReviewSummaries?: Array<{
     type: 'PROPOSAL' | 'THESIS'
     score?: number | null
     assessment?: 'GOOD' | 'ACCEPTABLE' | 'NEEDS_WORK' | null
     summary?: string | null
+    // The proposalId (PROPOSAL) or thesis fileId (THESIS) the review ran against. A summary
+    // whose version is not the latest upload describes a superseded document and is hidden.
+    documentVersionId?: string | null
     updatedAt: string
   }>
   grade: null | {

--- a/client/src/thesis/utils/feedbackLabels.ts
+++ b/client/src/thesis/utils/feedbackLabels.ts
@@ -1,0 +1,73 @@
+import {
+  ThesisFeedbackCategory,
+  ThesisFeedbackSeverity,
+  ThesisFeedbackSource,
+} from '@/thesis/requests/responses/thesis'
+
+export const humanizeFeedbackCategory = (
+  value: ThesisFeedbackCategory | string | null | undefined,
+): string => {
+  if (!value) return ''
+  return String(value)
+    .toLowerCase()
+    .replace(/(^\w|_\w)/g, (m) => m.replace('_', ' ').toUpperCase())
+}
+
+export const SEVERITY_COLOR: Record<ThesisFeedbackSeverity, string> = {
+  [ThesisFeedbackSeverity.CRITICAL]: 'red',
+  [ThesisFeedbackSeverity.MAJOR]: 'orange',
+  [ThesisFeedbackSeverity.MINOR]: 'yellow',
+  [ThesisFeedbackSeverity.SUGGESTION]: 'blue',
+}
+
+export const SEVERITY_DESCRIPTION: Record<ThesisFeedbackSeverity, string> = {
+  [ThesisFeedbackSeverity.CRITICAL]: 'Must be fixed before submission.',
+  [ThesisFeedbackSeverity.MAJOR]: 'Should be fixed before submission.',
+  [ThesisFeedbackSeverity.MINOR]: 'Nice to fix, but not blocking.',
+  [ThesisFeedbackSeverity.SUGGESTION]: 'An optional improvement.',
+}
+
+export const CATEGORY_DESCRIPTION: Record<ThesisFeedbackCategory, string> = {
+  [ThesisFeedbackCategory.FORMATTING]: 'Layout, headings, and general document formatting.',
+  [ThesisFeedbackCategory.STRUCTURE]: 'Required sections, chapter order, and overall structure.',
+  [ThesisFeedbackCategory.CITATION]: 'Bibliography, references, and citation style.',
+  [ThesisFeedbackCategory.METHODOLOGY]: 'Research approach, design, and rigor.',
+  [ThesisFeedbackCategory.WRITING]: 'Writing style, grammar, and clarity.',
+  [ThesisFeedbackCategory.FIGURES]: 'Figures, diagrams, and tables.',
+  [ThesisFeedbackCategory.LOGIC]: 'Argumentation and logical consistency.',
+  [ThesisFeedbackCategory.COMPLETENESS]: 'Missing content or insufficient detail.',
+  [ThesisFeedbackCategory.OTHER]: "Doesn't fit any other category.",
+}
+
+export const SOURCE_LABEL: Record<ThesisFeedbackSource, string> = {
+  [ThesisFeedbackSource.AI]: 'AI',
+  [ThesisFeedbackSource.HUMAN]: 'Instructor',
+  [ThesisFeedbackSource.AI_REVIEWED_BY_HUMAN]: 'AI + Instructor',
+}
+
+export const SOURCE_COLOR: Record<ThesisFeedbackSource, string> = {
+  [ThesisFeedbackSource.AI]: 'grape',
+  [ThesisFeedbackSource.HUMAN]: 'gray',
+  [ThesisFeedbackSource.AI_REVIEWED_BY_HUMAN]: 'teal',
+}
+
+export const SOURCE_DESCRIPTION: Record<ThesisFeedbackSource, string> = {
+  [ThesisFeedbackSource.AI]: 'Generated automatically by the AI review — not reviewed by a human.',
+  [ThesisFeedbackSource.HUMAN]: 'Written manually by an instructor.',
+  [ThesisFeedbackSource.AI_REVIEWED_BY_HUMAN]:
+    'An AI-generated finding an instructor reviewed and approved before saving.',
+}
+
+export type AIAssessment = 'GOOD' | 'ACCEPTABLE' | 'NEEDS_WORK'
+
+export const ASSESSMENT_LABEL: Record<AIAssessment, string> = {
+  GOOD: 'Good — ready to submit with minor tweaks',
+  ACCEPTABLE: 'Acceptable — some work needed',
+  NEEDS_WORK: 'Needs work — significant issues remain',
+}
+
+export const ASSESSMENT_COLOR: Record<AIAssessment, string> = {
+  GOOD: 'green',
+  ACCEPTABLE: 'yellow',
+  NEEDS_WORK: 'red',
+}

--- a/server/src/main/java/de/tum/cit/aet/thesis/feedback/dto/AIPreviewResponseDTO.java
+++ b/server/src/main/java/de/tum/cit/aet/thesis/feedback/dto/AIPreviewResponseDTO.java
@@ -12,6 +12,7 @@ import java.util.List;
 @JsonInclude(JsonInclude.Include.NON_EMPTY)
 public record AIPreviewResponseDTO(
 		AssessmentCategory assessment,
+		Integer score,
 		String summary,
 		List<AIFeedbackDraftDTO> drafts
 ) {}

--- a/server/src/main/java/de/tum/cit/aet/thesis/feedback/dto/ReviewResultDTO.java
+++ b/server/src/main/java/de/tum/cit/aet/thesis/feedback/dto/ReviewResultDTO.java
@@ -5,5 +5,5 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import java.util.List;
 
 @JsonInclude(JsonInclude.Include.NON_EMPTY)
-public record ReviewResultDTO(AssessmentCategory category, String summary, List<FindingDTO> findings) {
+public record ReviewResultDTO(AssessmentCategory category, Integer score, String summary, List<FindingDTO> findings) {
 }

--- a/server/src/main/java/de/tum/cit/aet/thesis/feedback/entity/AIReviewSummary.java
+++ b/server/src/main/java/de/tum/cit/aet/thesis/feedback/entity/AIReviewSummary.java
@@ -25,9 +25,9 @@ import java.util.UUID;
 
 /**
  * The AI review pipeline's latest read on a thesis's proposal or thesis document: a numeric
- * score, the {@link AssessmentCategory}, and a short summary. There is at most one record per
- * {@code (thesis, type)} pair — every review run (student auto-review or supervisor preview)
- * upserts this row, independent of whether any resulting findings are actually saved.
+ * score, the {@link AssessmentCategory}, a short summary, and the document revision it was
+ * produced from. There is at most one record per {@code (thesis, type)} pair — each auto-review
+ * run upserts this row, independent of whether any resulting findings are actually saved.
  */
 @Getter
 @Setter
@@ -56,6 +56,16 @@ public class AIReviewSummary {
 
 	@Column(name = "summary", columnDefinition = "text")
 	private String summary;
+
+	/**
+	 * The revision this summary was produced from — a {@code thesis_proposals} id for
+	 * {@link ReviewType#PROPOSAL}, a {@code thesis_files} id for {@link ReviewType#THESIS}. Lets
+	 * the UI drop the score once a newer document is uploaded rather than showing a stale one as
+	 * current. Null for rows written before the column existed, or when the reviewed document
+	 * could not be resolved.
+	 */
+	@Column(name = "document_version_id")
+	private UUID documentVersionId;
 
 	@UpdateTimestamp
 	@Column(name = "updated_at", nullable = false)

--- a/server/src/main/java/de/tum/cit/aet/thesis/feedback/entity/AIReviewSummary.java
+++ b/server/src/main/java/de/tum/cit/aet/thesis/feedback/entity/AIReviewSummary.java
@@ -1,0 +1,63 @@
+package de.tum.cit.aet.thesis.feedback.entity;
+
+import de.tum.cit.aet.thesis.feedback.dto.AssessmentCategory;
+import de.tum.cit.aet.thesis.feedback.service.reviewer.ReviewType;
+import de.tum.cit.aet.thesis.thesis.entity.Thesis;
+import lombok.Getter;
+import lombok.Setter;
+import org.hibernate.annotations.UpdateTimestamp;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+
+import java.time.Instant;
+import java.util.UUID;
+
+/**
+ * The AI review pipeline's latest read on a thesis's proposal or thesis document: a numeric
+ * score, the {@link AssessmentCategory}, and a short summary. There is at most one record per
+ * {@code (thesis, type)} pair — every review run (student auto-review or supervisor preview)
+ * upserts this row, independent of whether any resulting findings are actually saved.
+ */
+@Getter
+@Setter
+@Entity
+@Table(name = "ai_review_summary", uniqueConstraints = @UniqueConstraint(columnNames = {"thesis_id", "type"}))
+public class AIReviewSummary {
+	@Id
+	@GeneratedValue(strategy = GenerationType.UUID)
+	@Column(name = "ai_review_summary_id", nullable = false)
+	private UUID id;
+
+	@ManyToOne(fetch = FetchType.LAZY, optional = false)
+	@JoinColumn(name = "thesis_id", nullable = false)
+	private Thesis thesis;
+
+	@Enumerated(EnumType.STRING)
+	@Column(name = "type", nullable = false, length = 20)
+	private ReviewType type;
+
+	@Column(name = "score")
+	private Integer score;
+
+	@Enumerated(EnumType.STRING)
+	@Column(name = "assessment", length = 20)
+	private AssessmentCategory assessment;
+
+	@Column(name = "summary", columnDefinition = "text")
+	private String summary;
+
+	@UpdateTimestamp
+	@Column(name = "updated_at", nullable = false)
+	private Instant updatedAt;
+}

--- a/server/src/main/java/de/tum/cit/aet/thesis/feedback/repository/AIReviewSummaryRepository.java
+++ b/server/src/main/java/de/tum/cit/aet/thesis/feedback/repository/AIReviewSummaryRepository.java
@@ -1,0 +1,14 @@
+package de.tum.cit.aet.thesis.feedback.repository;
+
+import de.tum.cit.aet.thesis.feedback.entity.AIReviewSummary;
+import de.tum.cit.aet.thesis.feedback.service.reviewer.ReviewType;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+import java.util.UUID;
+
+@Repository
+public interface AIReviewSummaryRepository extends JpaRepository<AIReviewSummary, UUID> {
+	Optional<AIReviewSummary> findByThesisIdAndType(UUID thesisId, ReviewType type);
+}

--- a/server/src/main/java/de/tum/cit/aet/thesis/feedback/service/AIFeedbackService.java
+++ b/server/src/main/java/de/tum/cit/aet/thesis/feedback/service/AIFeedbackService.java
@@ -169,7 +169,7 @@ public class AIFeedbackService {
 				))
 				.toList();
 
-		return new AIPreviewResponseDTO(result.category(), result.score(), result.summary(), drafts);
+		return new AIPreviewResponseDTO(result.category(), sanitizeScore(result.score()), result.summary(), drafts);
 	}
 
 	/**
@@ -207,9 +207,24 @@ public class AIFeedbackService {
 			ReviewResultDTO result) {
 		summary.setThesis(thesis);
 		summary.setType(reviewType);
-		summary.setScore(result.score());
+		summary.setScore(sanitizeScore(result.score()));
 		summary.setAssessment(result.category());
 		summary.setSummary(result.summary());
+	}
+
+	/**
+	 * The score comes straight from the merger LLM's structured output — the prompt asks for an
+	 * integer 0-100, but nothing enforces that at the schema level. Treat a missing or
+	 * out-of-range value as "no score" rather than persisting or returning a bogus number.
+	 *
+	 * @param score the raw score reported by the review pipeline
+	 * @return the score if it is a valid integer in [0, 100], otherwise {@code null}
+	 */
+	private static Integer sanitizeScore(Integer score) {
+		if (score == null || score < 0 || score > 100) {
+			return null;
+		}
+		return score;
 	}
 
 	private Resource loadPdfResource(Thesis thesis, ReviewType reviewType) {

--- a/server/src/main/java/de/tum/cit/aet/thesis/feedback/service/AIFeedbackService.java
+++ b/server/src/main/java/de/tum/cit/aet/thesis/feedback/service/AIFeedbackService.java
@@ -16,6 +16,7 @@ import de.tum.cit.aet.thesis.feedback.repository.AIReviewSummaryRepository;
 import de.tum.cit.aet.thesis.feedback.repository.ResearchGroupGuidelinesRepository;
 import de.tum.cit.aet.thesis.feedback.service.reviewer.ReviewType;
 import de.tum.cit.aet.thesis.proposal.entity.ThesisProposal;
+import de.tum.cit.aet.thesis.proposal.repository.ThesisProposalRepository;
 import de.tum.cit.aet.thesis.thesis.constants.ThesisFeedbackCategory;
 import de.tum.cit.aet.thesis.thesis.constants.ThesisFeedbackSeverity;
 import de.tum.cit.aet.thesis.thesis.constants.ThesisFeedbackSource;
@@ -23,6 +24,7 @@ import de.tum.cit.aet.thesis.thesis.constants.ThesisFeedbackType;
 import de.tum.cit.aet.thesis.thesis.controller.payload.RequestChangesPayload;
 import de.tum.cit.aet.thesis.thesis.entity.Thesis;
 import de.tum.cit.aet.thesis.thesis.entity.ThesisFile;
+import de.tum.cit.aet.thesis.thesis.repository.ThesisFileRepository;
 import de.tum.cit.aet.thesis.thesis.service.ThesisService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -77,6 +79,8 @@ public class AIFeedbackService {
 	private final ThesisService thesisService;
 	private final ResearchGroupGuidelinesRepository guidelinesRepository;
 	private final AIReviewSummaryRepository reviewSummaryRepository;
+	private final ThesisProposalRepository proposalRepository;
+	private final ThesisFileRepository thesisFileRepository;
 
 	/**
 	 * Creates the AI feedback service.
@@ -86,16 +90,22 @@ public class AIFeedbackService {
 	 * @param guidelinesRepository the repository used to load and gate on per-group review guidelines
 	 * @param reviewSummaryRepository the repository used to persist the latest score/assessment/summary
 	 *                                per (thesis, review type)
+	 * @param proposalRepository the repository used to re-check which proposal is currently the newest
+	 * @param thesisFileRepository the repository used to re-check which thesis file is currently the newest
 	 */
 	public AIFeedbackService(
 			ReviewService reviewService,
 			ThesisService thesisService,
 			ResearchGroupGuidelinesRepository guidelinesRepository,
-			AIReviewSummaryRepository reviewSummaryRepository) {
+			AIReviewSummaryRepository reviewSummaryRepository,
+			ThesisProposalRepository proposalRepository,
+			ThesisFileRepository thesisFileRepository) {
 		this.reviewService = reviewService;
 		this.thesisService = thesisService;
 		this.guidelinesRepository = guidelinesRepository;
 		this.reviewSummaryRepository = reviewSummaryRepository;
+		this.proposalRepository = proposalRepository;
+		this.thesisFileRepository = thesisFileRepository;
 	}
 
 	/**
@@ -188,6 +198,16 @@ public class AIFeedbackService {
 	 */
 	private void persistReviewSummary(Thesis thesis, ReviewType reviewType, ReviewResultDTO result,
 			UUID documentVersionId) {
+		// A review takes long enough for the student to upload a new document while it runs. The
+		// single (thesis, type) row would then be overwritten with a result about a superseded
+		// revision — clobbering the summary of a review that already finished for the newer one.
+		// Drop the stale result instead; the row stays on whatever revision is actually current.
+		if (!isCurrentRevision(thesis, reviewType, documentVersionId)) {
+			log.info("Discarding AI review summary for thesis {} ({}): reviewed revision {} is no longer current",
+					thesis.getId(), reviewType, documentVersionId);
+			return;
+		}
+
 		AIReviewSummary summary = reviewSummaryRepository
 				.findByThesisIdAndType(thesis.getId(), reviewType)
 				.orElseGet(AIReviewSummary::new);
@@ -215,6 +235,32 @@ public class AIFeedbackService {
 		summary.setAssessment(result.category());
 		summary.setSummary(result.summary());
 		summary.setDocumentVersionId(documentVersionId);
+	}
+
+	/**
+	 * Whether the revision a review ran against is still the thesis's newest upload.
+	 *
+	 * <p>Reads the current revision from the database rather than from {@code thesis}: that
+	 * entity's proposal/file collections were initialised before the review started, so they
+	 * cannot show an upload that landed while the (potentially minute-long) pipeline was running.
+	 *
+	 * @param thesis the thesis that was reviewed
+	 * @param reviewType whether the proposal or the thesis document was reviewed
+	 * @param documentVersionId the revision the review ran against
+	 * @return {@code true} when that revision is still the newest one
+	 */
+	private boolean isCurrentRevision(Thesis thesis, ReviewType reviewType, UUID documentVersionId) {
+		UUID currentVersionId = switch (reviewType) {
+			case PROPOSAL -> proposalRepository.findFirstByThesisIdOrderByCreatedAtDesc(thesis.getId())
+					.map(ThesisProposal::getId)
+					.orElse(null);
+			case THESIS -> thesisFileRepository
+					.findFirstByThesisIdAndTypeOrderByUploadedAtDesc(thesis.getId(), "THESIS")
+					.map(ThesisFile::getId)
+					.orElse(null);
+		};
+
+		return currentVersionId != null && currentVersionId.equals(documentVersionId);
 	}
 
 	/**

--- a/server/src/main/java/de/tum/cit/aet/thesis/feedback/service/AIFeedbackService.java
+++ b/server/src/main/java/de/tum/cit/aet/thesis/feedback/service/AIFeedbackService.java
@@ -142,6 +142,12 @@ public class AIFeedbackService {
 	 * anything to the database. The instructor UI can then let the user tweak, accept, or drop
 	 * individual entries before persisting them.
 	 *
+	 * <p>Deliberately does NOT call {@link #persistReviewSummary}: a preview is supervisor-only
+	 * and provisional — the instructor may edit or discard every draft before saving anything.
+	 * The persisted summary backs the "Overall Score" shown on the student-visible feedback
+	 * overview, so persisting a discarded preview's score/summary there would leak content the
+	 * instructor never approved.
+	 *
 	 * @param thesis the thesis whose uploaded document is reviewed
 	 * @param reviewType whether to review the proposal or the thesis document
 	 * @return the assessment, summary, and editable drafts
@@ -150,7 +156,6 @@ public class AIFeedbackService {
 		StructuredGuidelines guidelines = requireReadyGuidelines(thesis);
 		Resource pdfResource = loadPdfResource(thesis, reviewType);
 		ReviewResultDTO result = reviewService.review(pdfResource, reviewType, guidelines);
-		persistReviewSummary(thesis, reviewType, result);
 
 		List<AIFeedbackDraftDTO> drafts = safeFindings(result.findings()).stream()
 				.map(finding -> new AIFeedbackDraftDTO(
@@ -169,9 +174,10 @@ public class AIFeedbackService {
 
 	/**
 	 * Upserts the {@code (thesis, reviewType)} row recording the AI review pipeline's latest
-	 * score, assessment, and summary — independent of whether the resulting findings are ever
-	 * saved. Called after every review run (auto or preview) so the feedback overview can show a
-	 * running "Overall Score" without depending on the caller having accepted any drafts.
+	 * score, assessment, and summary. Only called from {@link #autoReviewAndSave} — that flow
+	 * always saves its findings as real, already-visible {@code ThesisFeedback} rows, so the
+	 * summary describes content the student can already see. {@link #previewReview} must NOT call
+	 * this (see its Javadoc).
 	 *
 	 * @param thesis the thesis that was reviewed
 	 * @param reviewType whether the proposal or the thesis document was reviewed

--- a/server/src/main/java/de/tum/cit/aet/thesis/feedback/service/AIFeedbackService.java
+++ b/server/src/main/java/de/tum/cit/aet/thesis/feedback/service/AIFeedbackService.java
@@ -9,8 +9,10 @@ import de.tum.cit.aet.thesis.feedback.dto.AIPreviewResponseDTO;
 import de.tum.cit.aet.thesis.feedback.dto.FindingDTO;
 import de.tum.cit.aet.thesis.feedback.dto.Location;
 import de.tum.cit.aet.thesis.feedback.dto.ReviewResultDTO;
+import de.tum.cit.aet.thesis.feedback.entity.AIReviewSummary;
 import de.tum.cit.aet.thesis.feedback.entity.ResearchGroupGuidelines;
 import de.tum.cit.aet.thesis.feedback.entity.jsonb.StructuredGuidelines;
+import de.tum.cit.aet.thesis.feedback.repository.AIReviewSummaryRepository;
 import de.tum.cit.aet.thesis.feedback.repository.ResearchGroupGuidelinesRepository;
 import de.tum.cit.aet.thesis.feedback.service.reviewer.ReviewType;
 import de.tum.cit.aet.thesis.proposal.entity.ThesisProposal;
@@ -72,6 +74,7 @@ public class AIFeedbackService {
 	private final ReviewService reviewService;
 	private final ThesisService thesisService;
 	private final ResearchGroupGuidelinesRepository guidelinesRepository;
+	private final AIReviewSummaryRepository reviewSummaryRepository;
 
 	/**
 	 * Creates the AI feedback service.
@@ -79,14 +82,18 @@ public class AIFeedbackService {
 	 * @param reviewService the pipeline that runs the LLM review over a PDF
 	 * @param thesisService the service used to load documents and persist feedback
 	 * @param guidelinesRepository the repository used to load and gate on per-group review guidelines
+	 * @param reviewSummaryRepository the repository used to persist the latest score/assessment/summary
+	 *                                per (thesis, review type)
 	 */
 	public AIFeedbackService(
 			ReviewService reviewService,
 			ThesisService thesisService,
-			ResearchGroupGuidelinesRepository guidelinesRepository) {
+			ResearchGroupGuidelinesRepository guidelinesRepository,
+			AIReviewSummaryRepository reviewSummaryRepository) {
 		this.reviewService = reviewService;
 		this.thesisService = thesisService;
 		this.guidelinesRepository = guidelinesRepository;
+		this.reviewSummaryRepository = reviewSummaryRepository;
 	}
 
 	/**
@@ -102,6 +109,7 @@ public class AIFeedbackService {
 		StructuredGuidelines guidelines = requireReadyGuidelines(thesis);
 		Resource pdfResource = loadPdfResource(thesis, reviewType);
 		ReviewResultDTO result = reviewService.review(pdfResource, reviewType, guidelines);
+		persistReviewSummary(thesis, reviewType, result);
 
 		List<RequestChangesPayload.RequestedChange> changes = new ArrayList<>();
 		for (FindingDTO finding : safeFindings(result.findings())) {
@@ -141,6 +149,7 @@ public class AIFeedbackService {
 		StructuredGuidelines guidelines = requireReadyGuidelines(thesis);
 		Resource pdfResource = loadPdfResource(thesis, reviewType);
 		ReviewResultDTO result = reviewService.review(pdfResource, reviewType, guidelines);
+		persistReviewSummary(thesis, reviewType, result);
 
 		List<AIFeedbackDraftDTO> drafts = safeFindings(result.findings()).stream()
 				.map(finding -> new AIFeedbackDraftDTO(
@@ -154,7 +163,29 @@ public class AIFeedbackService {
 				))
 				.toList();
 
-		return new AIPreviewResponseDTO(result.category(), result.summary(), drafts);
+		return new AIPreviewResponseDTO(result.category(), result.score(), result.summary(), drafts);
+	}
+
+	/**
+	 * Upserts the {@code (thesis, reviewType)} row recording the AI review pipeline's latest
+	 * score, assessment, and summary — independent of whether the resulting findings are ever
+	 * saved. Called after every review run (auto or preview) so the feedback overview can show a
+	 * running "Overall Score" without depending on the caller having accepted any drafts.
+	 *
+	 * @param thesis the thesis that was reviewed
+	 * @param reviewType whether the proposal or the thesis document was reviewed
+	 * @param result the merged review result to persist
+	 */
+	private void persistReviewSummary(Thesis thesis, ReviewType reviewType, ReviewResultDTO result) {
+		AIReviewSummary summary = reviewSummaryRepository
+				.findByThesisIdAndType(thesis.getId(), reviewType)
+				.orElseGet(AIReviewSummary::new);
+		summary.setThesis(thesis);
+		summary.setType(reviewType);
+		summary.setScore(result.score());
+		summary.setAssessment(result.category());
+		summary.setSummary(result.summary());
+		reviewSummaryRepository.save(summary);
 	}
 
 	private Resource loadPdfResource(Thesis thesis, ReviewType reviewType) {

--- a/server/src/main/java/de/tum/cit/aet/thesis/feedback/service/AIFeedbackService.java
+++ b/server/src/main/java/de/tum/cit/aet/thesis/feedback/service/AIFeedbackService.java
@@ -35,6 +35,7 @@ import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Locale;
+import java.util.UUID;
 
 /**
  * Runs the AI review pipeline against a thesis's existing uploaded PDF and either (a) persists
@@ -108,9 +109,9 @@ public class AIFeedbackService {
 	 */
 	public Thesis autoReviewAndSave(Thesis thesis, ReviewType reviewType) {
 		StructuredGuidelines guidelines = requireReadyGuidelines(thesis);
-		Resource pdfResource = loadPdfResource(thesis, reviewType);
-		ReviewResultDTO result = reviewService.review(pdfResource, reviewType, guidelines);
-		persistReviewSummary(thesis, reviewType, result);
+		ReviewDocument document = loadReviewDocument(thesis, reviewType);
+		ReviewResultDTO result = reviewService.review(document.resource(), reviewType, guidelines);
+		persistReviewSummary(thesis, reviewType, result, document.versionId());
 
 		List<RequestChangesPayload.RequestedChange> changes = new ArrayList<>();
 		for (FindingDTO finding : safeFindings(result.findings())) {
@@ -154,8 +155,8 @@ public class AIFeedbackService {
 	 */
 	public AIPreviewResponseDTO previewReview(Thesis thesis, ReviewType reviewType) {
 		StructuredGuidelines guidelines = requireReadyGuidelines(thesis);
-		Resource pdfResource = loadPdfResource(thesis, reviewType);
-		ReviewResultDTO result = reviewService.review(pdfResource, reviewType, guidelines);
+		ReviewDocument document = loadReviewDocument(thesis, reviewType);
+		ReviewResultDTO result = reviewService.review(document.resource(), reviewType, guidelines);
 
 		List<AIFeedbackDraftDTO> drafts = safeFindings(result.findings()).stream()
 				.map(finding -> new AIFeedbackDraftDTO(
@@ -182,12 +183,15 @@ public class AIFeedbackService {
 	 * @param thesis the thesis that was reviewed
 	 * @param reviewType whether the proposal or the thesis document was reviewed
 	 * @param result the merged review result to persist
+	 * @param documentVersionId the id of the document revision the review ran against, so the UI
+	 *                          can tell a current summary from one describing an older upload
 	 */
-	private void persistReviewSummary(Thesis thesis, ReviewType reviewType, ReviewResultDTO result) {
+	private void persistReviewSummary(Thesis thesis, ReviewType reviewType, ReviewResultDTO result,
+			UUID documentVersionId) {
 		AIReviewSummary summary = reviewSummaryRepository
 				.findByThesisIdAndType(thesis.getId(), reviewType)
 				.orElseGet(AIReviewSummary::new);
-		applyReviewResult(summary, thesis, reviewType, result);
+		applyReviewResult(summary, thesis, reviewType, result, documentVersionId);
 
 		try {
 			reviewSummaryRepository.save(summary);
@@ -198,18 +202,19 @@ public class AIFeedbackService {
 			AIReviewSummary existing = reviewSummaryRepository
 					.findByThesisIdAndType(thesis.getId(), reviewType)
 					.orElseThrow(() -> e);
-			applyReviewResult(existing, thesis, reviewType, result);
+			applyReviewResult(existing, thesis, reviewType, result, documentVersionId);
 			reviewSummaryRepository.save(existing);
 		}
 	}
 
 	private static void applyReviewResult(AIReviewSummary summary, Thesis thesis, ReviewType reviewType,
-			ReviewResultDTO result) {
+			ReviewResultDTO result, UUID documentVersionId) {
 		summary.setThesis(thesis);
 		summary.setType(reviewType);
 		summary.setScore(sanitizeScore(result.score()));
 		summary.setAssessment(result.category());
 		summary.setSummary(result.summary());
+		summary.setDocumentVersionId(documentVersionId);
 	}
 
 	/**
@@ -227,7 +232,18 @@ public class AIFeedbackService {
 		return score;
 	}
 
-	private Resource loadPdfResource(Thesis thesis, ReviewType reviewType) {
+	/**
+	 * The document a review run reads, paired with the id of the revision it came from. Reviews
+	 * always run against the newest upload, and the id is what lets a persisted summary be
+	 * recognised as stale once a newer proposal or thesis file replaces it.
+	 *
+	 * @param resource the PDF handed to the review pipeline
+	 * @param versionId the {@code thesis_proposals} / {@code thesis_files} id of that revision
+	 */
+	private record ReviewDocument(Resource resource, UUID versionId) {
+	}
+
+	private ReviewDocument loadReviewDocument(Thesis thesis, ReviewType reviewType) {
 		return switch (reviewType) {
 			case PROPOSAL -> {
 				List<ThesisProposal> proposals = thesis.getProposals();
@@ -235,13 +251,14 @@ public class AIFeedbackService {
 					throw new ResourceInvalidParametersException(
 							"Thesis has no uploaded proposal — cannot run an AI review.");
 				}
-				yield thesisService.getProposalFile(proposals.getFirst());
+				ThesisProposal proposal = proposals.getFirst();
+				yield new ReviewDocument(thesisService.getProposalFile(proposal), proposal.getId());
 			}
 			case THESIS -> {
 				ThesisFile thesisFile = thesis.getLatestFile("THESIS").orElseThrow(() ->
 						new ResourceInvalidParametersException(
 								"Thesis has no uploaded thesis document — cannot run an AI review."));
-				yield thesisService.getThesisFile(thesisFile);
+				yield new ReviewDocument(thesisService.getThesisFile(thesisFile), thesisFile.getId());
 			}
 		};
 	}
@@ -348,7 +365,7 @@ public class AIFeedbackService {
 	 * @param reviewType whether the proposal or the thesis document is required
 	 */
 	public void assertHasDocument(Thesis thesis, ReviewType reviewType) {
-		loadPdfResource(thesis, reviewType);
+		loadReviewDocument(thesis, reviewType);
 	}
 
 	/**

--- a/server/src/main/java/de/tum/cit/aet/thesis/feedback/service/AIFeedbackService.java
+++ b/server/src/main/java/de/tum/cit/aet/thesis/feedback/service/AIFeedbackService.java
@@ -121,7 +121,6 @@ public class AIFeedbackService {
 		StructuredGuidelines guidelines = requireReadyGuidelines(thesis);
 		ReviewDocument document = loadReviewDocument(thesis, reviewType);
 		ReviewResultDTO result = reviewService.review(document.resource(), reviewType, guidelines);
-		persistReviewSummary(thesis, reviewType, result, document.versionId());
 
 		List<RequestChangesPayload.RequestedChange> changes = new ArrayList<>();
 		for (FindingDTO finding : safeFindings(result.findings())) {
@@ -135,17 +134,24 @@ public class AIFeedbackService {
 			));
 		}
 
+		Thesis reviewed = thesis;
 		if (changes.isEmpty()) {
 			log.info("AI auto review for thesis {} ({}) produced no actionable findings", thesis.getId(), reviewType);
-			return thesis;
+		} else {
+			reviewed = thesisService.requestChanges(
+					thesis,
+					toFeedbackType(reviewType),
+					changes,
+					ThesisFeedbackSource.AI
+			);
 		}
 
-		return thesisService.requestChanges(
-				thesis,
-				toFeedbackType(reviewType),
-				changes,
-				ThesisFeedbackSource.AI
-		);
+		// Last, so the summary only ever describes findings that actually landed: requestChanges
+		// is transactional, and persisting the score first would leave it standing on its own if
+		// saving the feedback rows failed and rolled them back.
+		persistReviewSummary(thesis, reviewType, result, document.versionId());
+
+		return reviewed;
 	}
 
 	/**

--- a/server/src/main/java/de/tum/cit/aet/thesis/feedback/service/AIFeedbackService.java
+++ b/server/src/main/java/de/tum/cit/aet/thesis/feedback/service/AIFeedbackService.java
@@ -28,6 +28,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.context.annotation.Conditional;
 import org.springframework.core.io.Resource;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 
 import java.util.ArrayList;
@@ -180,12 +181,29 @@ public class AIFeedbackService {
 		AIReviewSummary summary = reviewSummaryRepository
 				.findByThesisIdAndType(thesis.getId(), reviewType)
 				.orElseGet(AIReviewSummary::new);
+		applyReviewResult(summary, thesis, reviewType, result);
+
+		try {
+			reviewSummaryRepository.save(summary);
+		} catch (DataIntegrityViolationException e) {
+			// Two review runs for the same (thesis, type) raced: both found no existing row and
+			// both tried to insert. Retry as an update against the row the other one just
+			// created, so a concurrent request fails the review rather than this bookkeeping.
+			AIReviewSummary existing = reviewSummaryRepository
+					.findByThesisIdAndType(thesis.getId(), reviewType)
+					.orElseThrow(() -> e);
+			applyReviewResult(existing, thesis, reviewType, result);
+			reviewSummaryRepository.save(existing);
+		}
+	}
+
+	private static void applyReviewResult(AIReviewSummary summary, Thesis thesis, ReviewType reviewType,
+			ReviewResultDTO result) {
 		summary.setThesis(thesis);
 		summary.setType(reviewType);
 		summary.setScore(result.score());
 		summary.setAssessment(result.category());
 		summary.setSummary(result.summary());
-		reviewSummaryRepository.save(summary);
 	}
 
 	private Resource loadPdfResource(Thesis thesis, ReviewType reviewType) {

--- a/server/src/main/java/de/tum/cit/aet/thesis/feedback/service/reviewer/Prompts.java
+++ b/server/src/main/java/de/tum/cit/aet/thesis/feedback/service/reviewer/Prompts.java
@@ -525,7 +525,8 @@ public enum Prompts {
 					3. FILTER: Remove any findings that are not actionable or are actually positive observations (e.g. "The proposal clearly explains the research question" or "Bibliography meets requirements")
 					4. RANK: Sort by severity (critical → major → minor → suggestion)
 					5. ASSESS: Provide an overall assessment of the proposal quality
-					6. LIMIT: Produce 0-25 actionable feedback items total. If all check groups returned zero findings (or only positive observations), return an empty findings array. Do not invent issues to fill a quota.
+					6. SCORE: Provide an integer "score" from 0-100 reflecting overall quality, consistent with your assessment (good ≈ 80-100, acceptable ≈ 50-79, needs-work ≈ 0-49). Weigh critical/major findings more heavily than minor ones/suggestions.
+					7. LIMIT: Produce 0-25 actionable feedback items total. If all check groups returned zero findings (or only positive observations), return an empty findings array. Do not invent issues to fill a quota.
 
 					Rules:
 					- Keep the severity levels as assigned by the check groups unless clearly wrong
@@ -550,7 +551,8 @@ public enum Prompts {
 					3. FILTER: Remove any findings that are not actionable or are actually positive observations
 					4. RANK: Sort by severity (critical → major → minor → suggestion)
 					5. ASSESS: Provide an overall assessment of the thesis quality
-					6. LIMIT: Produce 0-40 actionable feedback items total (a thesis is longer than a proposal and legitimately generates more findings). If all check groups returned zero findings (or only positive observations), return an empty findings array. Do not invent issues to fill a quota.
+					6. SCORE: Provide an integer "score" from 0-100 reflecting overall quality, consistent with your assessment (good ≈ 80-100, acceptable ≈ 50-79, needs-work ≈ 0-49). Weigh critical/major findings more heavily than minor ones/suggestions.
+					7. LIMIT: Produce 0-40 actionable feedback items total (a thesis is longer than a proposal and legitimately generates more findings). If all check groups returned zero findings (or only positive observations), return an empty findings array. Do not invent issues to fill a quota.
 
 					Rules:
 					- Keep the severity levels as assigned by the check groups unless clearly wrong

--- a/server/src/main/java/de/tum/cit/aet/thesis/proposal/repository/ThesisProposalRepository.java
+++ b/server/src/main/java/de/tum/cit/aet/thesis/proposal/repository/ThesisProposalRepository.java
@@ -9,6 +9,7 @@ import org.springframework.stereotype.Repository;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 
 @Repository
@@ -19,4 +20,11 @@ public interface ThesisProposalRepository extends JpaRepository<ThesisProposal, 
 
 	@Query("SELECT p.proposalFilename FROM ThesisProposal p WHERE p.thesis.id = :thesisId AND p.proposalFilename IS NOT NULL")
 	List<String> findFilenamesByThesisId(@Param("thesisId") UUID thesisId);
+
+	/**
+	 * The thesis's newest proposal, read straight from the database. Mirrors the
+	 * {@code createdAt DESC} ordering of {@code Thesis.proposals}, but without going through that
+	 * lazy collection — callers use this precisely when the in-memory snapshot may be outdated.
+	 */
+	Optional<ThesisProposal> findFirstByThesisIdOrderByCreatedAtDesc(UUID thesisId);
 }

--- a/server/src/main/java/de/tum/cit/aet/thesis/thesis/dto/ThesisDto.java
+++ b/server/src/main/java/de/tum/cit/aet/thesis/thesis/dto/ThesisDto.java
@@ -4,6 +4,9 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import de.tum.cit.aet.thesis.core.group.dto.LightResearchGroupDto;
 import de.tum.cit.aet.thesis.core.user.dto.LightUserDto;
 import de.tum.cit.aet.thesis.core.user.dto.MinimalUserDto;
+import de.tum.cit.aet.thesis.feedback.dto.AssessmentCategory;
+import de.tum.cit.aet.thesis.feedback.entity.AIReviewSummary;
+import de.tum.cit.aet.thesis.feedback.service.reviewer.ReviewType;
 import de.tum.cit.aet.thesis.presentation.constants.ThesisPresentationState;
 import de.tum.cit.aet.thesis.presentation.constants.ThesisPresentationType;
 import de.tum.cit.aet.thesis.presentation.constants.ThesisPresentationVisibility;
@@ -55,6 +58,7 @@ public record ThesisDto(
 	List<ThesisFeedbackDto> feedback,
 	List<ThesisFilesDto> files,
 	ThesisGradeDto grade,
+	List<ThesisAIReviewSummaryDto> aiReviewSummaries,
 
 	List<ThesisPresentationDto> presentations,
 
@@ -131,6 +135,7 @@ public static ThesisDto fromThesisEntity(Thesis thesis, boolean supervisorAccess
 		thesis.getFeedback().stream().map(ThesisFeedbackDto::fromThesisFeedbackEntity).toList(),
 		thesis.getFiles().stream().map(ThesisFilesDto::fromThesisFileEntity).toList(),
 		studentAccess ? ThesisGradeDto.fromThesisEntity(thesis) : null,
+		thesis.getAiReviewSummaries().stream().map(ThesisAIReviewSummaryDto::fromEntity).toList(),
 		presentations.stream().map(ThesisPresentationDto::fromPresentationEntity).toList(),
 		students,
 		supervisors,
@@ -262,6 +267,30 @@ public record ThesisFeedbackDto(
 		feedback.getSeverity(),
 		feedback.getGenerationSource(),
 		feedback.getDocumentVersionId()
+	);
+	}
+}
+
+@JsonInclude(JsonInclude.Include.NON_EMPTY)
+public record ThesisAIReviewSummaryDto(
+	ReviewType type,
+	Integer score,
+	AssessmentCategory assessment,
+	String summary,
+	Instant updatedAt
+) {
+
+	public static ThesisAIReviewSummaryDto fromEntity(AIReviewSummary summary) {
+	if (summary == null) {
+		return null;
+	}
+
+	return new ThesisAIReviewSummaryDto(
+		summary.getType(),
+		summary.getScore(),
+		summary.getAssessment(),
+		summary.getSummary(),
+		summary.getUpdatedAt()
 	);
 	}
 }

--- a/server/src/main/java/de/tum/cit/aet/thesis/thesis/dto/ThesisDto.java
+++ b/server/src/main/java/de/tum/cit/aet/thesis/thesis/dto/ThesisDto.java
@@ -277,6 +277,9 @@ public record ThesisAIReviewSummaryDto(
 	Integer score,
 	AssessmentCategory assessment,
 	String summary,
+	// Points at the proposalId (PROPOSAL) or thesis fileId (THESIS) the review ran against. The
+	// client compares it with the latest revision and hides the summary once it no longer matches.
+	UUID documentVersionId,
 	Instant updatedAt
 ) {
 
@@ -290,6 +293,7 @@ public record ThesisAIReviewSummaryDto(
 		summary.getScore(),
 		summary.getAssessment(),
 		summary.getSummary(),
+		summary.getDocumentVersionId(),
 		summary.getUpdatedAt()
 	);
 	}

--- a/server/src/main/java/de/tum/cit/aet/thesis/thesis/entity/Thesis.java
+++ b/server/src/main/java/de/tum/cit/aet/thesis/thesis/entity/Thesis.java
@@ -3,6 +3,7 @@ package de.tum.cit.aet.thesis.thesis.entity;
 import de.tum.cit.aet.thesis.core.application.entity.Application;
 import de.tum.cit.aet.thesis.core.group.entity.ResearchGroup;
 import de.tum.cit.aet.thesis.core.user.entity.User;
+import de.tum.cit.aet.thesis.feedback.entity.AIReviewSummary;
 import de.tum.cit.aet.thesis.presentation.entity.ThesisPresentation;
 import de.tum.cit.aet.thesis.proposal.entity.ThesisProposal;
 import de.tum.cit.aet.thesis.thesis.constants.ThesisAbstractSource;
@@ -154,6 +155,9 @@ public class Thesis {
 	@OneToMany(mappedBy = "thesis", fetch = FetchType.LAZY)
 	@OrderBy("uploadedAt DESC")
 	private List<ThesisFile> files = new ArrayList<>();
+
+	@OneToMany(mappedBy = "thesis", fetch = FetchType.LAZY)
+	private List<AIReviewSummary> aiReviewSummaries = new ArrayList<>();
 
 	@OneToMany(mappedBy = "thesis", fetch = FetchType.EAGER)
 	private Set<ThesisStateChange> states = new HashSet<>();

--- a/server/src/main/java/de/tum/cit/aet/thesis/thesis/repository/ThesisFileRepository.java
+++ b/server/src/main/java/de/tum/cit/aet/thesis/thesis/repository/ThesisFileRepository.java
@@ -9,6 +9,7 @@ import org.springframework.stereotype.Repository;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 
 
@@ -20,4 +21,11 @@ public interface ThesisFileRepository extends JpaRepository<ThesisFile, UUID> {
 
 	@Query("SELECT f.filename FROM ThesisFile f WHERE f.thesis.id = :thesisId")
 	List<String> findFilenamesByThesisId(@Param("thesisId") UUID thesisId);
+
+	/**
+	 * The thesis's newest file of the given type, read straight from the database. Mirrors what
+	 * {@code Thesis.getLatestFile} picks out of the {@code uploadedAt DESC} collection, but
+	 * without going through it — callers use this precisely when that snapshot may be outdated.
+	 */
+	Optional<ThesisFile> findFirstByThesisIdAndTypeOrderByUploadedAtDesc(UUID thesisId, String type);
 }

--- a/server/src/main/resources/db/changelog/changes/44_ai_review_summary.sql
+++ b/server/src/main/resources/db/changelog/changes/44_ai_review_summary.sql
@@ -10,7 +10,7 @@ CREATE TABLE ai_review_summary (
     ai_review_summary_id UUID PRIMARY KEY,
     thesis_id             UUID        NOT NULL REFERENCES theses (thesis_id) ON DELETE CASCADE,
     type                  VARCHAR(20) NOT NULL CHECK (type IN ('PROPOSAL', 'THESIS')),
-    score                 INTEGER,
+    score                 INTEGER     CHECK (score IS NULL OR (score >= 0 AND score <= 100)),
     assessment            VARCHAR(20) CHECK (assessment IS NULL OR assessment IN ('GOOD', 'ACCEPTABLE', 'NEEDS_WORK')),
     summary               TEXT,
     updated_at            TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),

--- a/server/src/main/resources/db/changelog/changes/44_ai_review_summary.sql
+++ b/server/src/main/resources/db/changelog/changes/44_ai_review_summary.sql
@@ -1,0 +1,18 @@
+--liquibase formatted sql
+
+--changeset thesis:44_ai_review_summary
+
+-- The AI review pipeline's latest read on a thesis's proposal or thesis document: a numeric
+-- score, an overall assessment, and a short summary. At most one row per (thesis_id, type) —
+-- every review run (student auto-review or supervisor preview) upserts this row, independent of
+-- whether any resulting findings are actually saved.
+CREATE TABLE ai_review_summary (
+    ai_review_summary_id UUID PRIMARY KEY,
+    thesis_id             UUID        NOT NULL REFERENCES theses (thesis_id) ON DELETE CASCADE,
+    type                  VARCHAR(20) NOT NULL CHECK (type IN ('PROPOSAL', 'THESIS')),
+    score                 INTEGER,
+    assessment            VARCHAR(20) CHECK (assessment IS NULL OR assessment IN ('GOOD', 'ACCEPTABLE', 'NEEDS_WORK')),
+    summary               TEXT,
+    updated_at            TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+    CONSTRAINT uq_ai_review_summary_thesis_type UNIQUE (thesis_id, type)
+);

--- a/server/src/main/resources/db/changelog/changes/45_ai_review_summary_document_version.sql
+++ b/server/src/main/resources/db/changelog/changes/45_ai_review_summary_document_version.sql
@@ -1,0 +1,11 @@
+--liquibase formatted sql
+
+--changeset thesis:45_ai_review_summary_document_version
+
+-- Ties each AI review summary to the proposal or thesis-file revision it was produced from, so
+-- the UI can hide an obsolete score once a newer document is uploaded instead of presenting it
+-- as the current one. Nullable because rows written before this column exist and we cannot tell
+-- retroactively which revision they described — those are treated as stale by the client.
+-- No FK constraint: the target table depends on `type` (PROPOSAL → thesis_proposals,
+-- THESIS → thesis_files), mirroring thesis_feedback.document_version_id.
+ALTER TABLE ai_review_summary ADD COLUMN document_version_id UUID;

--- a/server/src/main/resources/db/changelog/db.changelog-master.xml
+++ b/server/src/main/resources/db/changelog/db.changelog-master.xml
@@ -49,6 +49,7 @@
     <include file="changes/42_thesis_feedback_document_version.sql" relativeToChangelogFile="true" />
 
     <include file="changes/43_research_group_guidelines.sql" relativeToChangelogFile="true" />
+    <include file="changes/44_ai_review_summary.sql" relativeToChangelogFile="true" />
 
     <!-- Dev/test seed data — must be last so it can reference all columns from prior migrations -->
     <include file="changes/23_seed_dev_test_data.xml" relativeToChangelogFile="true" />

--- a/server/src/main/resources/db/changelog/db.changelog-master.xml
+++ b/server/src/main/resources/db/changelog/db.changelog-master.xml
@@ -50,6 +50,7 @@
 
     <include file="changes/43_research_group_guidelines.sql" relativeToChangelogFile="true" />
     <include file="changes/44_ai_review_summary.sql" relativeToChangelogFile="true" />
+    <include file="changes/45_ai_review_summary_document_version.sql" relativeToChangelogFile="true" />
 
     <!-- Dev/test seed data — must be last so it can reference all columns from prior migrations -->
     <include file="changes/23_seed_dev_test_data.xml" relativeToChangelogFile="true" />

--- a/server/src/test/java/de/tum/cit/aet/thesis/feedback/controller/ReviewControllerTest.java
+++ b/server/src/test/java/de/tum/cit/aet/thesis/feedback/controller/ReviewControllerTest.java
@@ -59,6 +59,7 @@ class ReviewControllerTest extends BaseIntegrationTest {
 						.header("Authorization", createRandomAdminAuthentication()))
 				.andExpect(status().isOk())
 				.andExpect(jsonPath("$.assessment").value("ACCEPTABLE"))
+				.andExpect(jsonPath("$.score").value(62))
 				.andExpect(jsonPath("$.summary").value("Solid overall but bibliography is thin."))
 				.andExpect(jsonPath("$.drafts[0].category").value("CITATION"))
 				.andExpect(jsonPath("$.drafts[0].severity").value("MAJOR"));
@@ -264,6 +265,7 @@ class ReviewControllerTest extends BaseIntegrationTest {
 	private void stubPreviewResponse() {
 		AIPreviewResponseDTO mockResponse = new AIPreviewResponseDTO(
 				AssessmentCategory.ACCEPTABLE,
+				62,
 				"Solid overall but bibliography is thin.",
 				List.of(new AIFeedbackDraftDTO(
 						"Thin bibliography — increase to at least 6 peer-reviewed sources.",

--- a/server/src/test/java/de/tum/cit/aet/thesis/feedback/service/AIFeedbackServiceTest.java
+++ b/server/src/test/java/de/tum/cit/aet/thesis/feedback/service/AIFeedbackServiceTest.java
@@ -10,9 +10,11 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import de.tum.cit.aet.thesis.core.exception.request.AccessDeniedException;
+import de.tum.cit.aet.thesis.core.exception.request.ResourceInvalidParametersException;
 import de.tum.cit.aet.thesis.core.group.entity.ResearchGroup;
 import de.tum.cit.aet.thesis.feedback.dto.AIPreviewResponseDTO;
 import de.tum.cit.aet.thesis.feedback.dto.AssessmentCategory;
+import de.tum.cit.aet.thesis.feedback.dto.FindingDTO;
 import de.tum.cit.aet.thesis.feedback.dto.ReviewResultDTO;
 import de.tum.cit.aet.thesis.feedback.entity.AIReviewSummary;
 import de.tum.cit.aet.thesis.feedback.entity.GuidelinesStatus;
@@ -274,6 +276,31 @@ class AIFeedbackServiceTest {
 		ArgumentCaptor<AIReviewSummary> savedSummary = ArgumentCaptor.forClass(AIReviewSummary.class);
 		verify(reviewSummaryRepository).save(savedSummary.capture());
 		assertThat(savedSummary.getValue().getDocumentVersionId()).isEqualTo(fileId);
+	}
+
+	@Test
+	void autoReviewAndSave_doesNotPersistTheSummaryWhenSavingTheFindingsFails() {
+		ResearchGroupGuidelines guidelines = readyGuidelines();
+		when(guidelinesRepository.findById(researchGroupId)).thenReturn(Optional.of(guidelines));
+
+		ThesisProposal proposal = org.mockito.Mockito.mock(ThesisProposal.class);
+		when(thesis.getProposals()).thenReturn(List.of(proposal));
+		Resource pdfResource = new ByteArrayResource("pdf".getBytes());
+		when(thesisService.getProposalFile(proposal)).thenReturn(pdfResource);
+
+		when(reviewService.review(eq(pdfResource), eq(ReviewType.PROPOSAL), eq(guidelines.getStructuredGuidelines())))
+				.thenReturn(new ReviewResultDTO(AssessmentCategory.NEEDS_WORK, 40, "Needs work.", List.of(
+						new FindingDTO("MAJOR", "STRUCTURE", "Missing related work", "Add a section.", List.of()))));
+
+		// requestChanges is transactional, so a rejected batch leaves no feedback rows behind —
+		// the score describing those rows must not be persisted on its own either.
+		when(thesisService.requestChanges(any(), any(), anyList(), any()))
+				.thenThrow(new ResourceInvalidParametersException("Feedback text too long"));
+
+		assertThatThrownBy(() -> service.autoReviewAndSave(thesis, ReviewType.PROPOSAL))
+				.isInstanceOf(ResourceInvalidParametersException.class);
+
+		verify(reviewSummaryRepository, never()).save(any());
 	}
 
 	@Test

--- a/server/src/test/java/de/tum/cit/aet/thesis/feedback/service/AIFeedbackServiceTest.java
+++ b/server/src/test/java/de/tum/cit/aet/thesis/feedback/service/AIFeedbackServiceTest.java
@@ -118,23 +118,15 @@ class AIFeedbackServiceTest {
 
 		when(reviewService.review(eq(pdfResource), eq(ReviewType.PROPOSAL), eq(guidelines.getStructuredGuidelines())))
 				.thenReturn(new ReviewResultDTO(AssessmentCategory.GOOD, 90, "All good.", List.of()));
-		UUID thesisId = UUID.randomUUID();
-		when(thesis.getId()).thenReturn(thesisId);
-		when(reviewSummaryRepository.findByThesisIdAndType(thesisId, ReviewType.PROPOSAL)).thenReturn(Optional.empty());
 
 		AIPreviewResponseDTO response = service.previewReview(thesis, ReviewType.PROPOSAL);
 
 		assertThat(response.summary()).isEqualTo("All good.");
 		assertThat(response.score()).isEqualTo(90);
 		verify(reviewService).review(pdfResource, ReviewType.PROPOSAL, guidelines.getStructuredGuidelines());
-
-		ArgumentCaptor<AIReviewSummary> savedSummary = ArgumentCaptor.forClass(AIReviewSummary.class);
-		verify(reviewSummaryRepository).save(savedSummary.capture());
-		assertThat(savedSummary.getValue().getThesis()).isEqualTo(thesis);
-		assertThat(savedSummary.getValue().getType()).isEqualTo(ReviewType.PROPOSAL);
-		assertThat(savedSummary.getValue().getScore()).isEqualTo(90);
-		assertThat(savedSummary.getValue().getAssessment()).isEqualTo(AssessmentCategory.GOOD);
-		assertThat(savedSummary.getValue().getSummary()).isEqualTo("All good.");
+		// A preview is supervisor-only and provisional (drafts may be edited/discarded), so it
+		// must never persist a summary the student-visible feedback overview would then show.
+		verify(reviewSummaryRepository, never()).save(any());
 	}
 
 	@Test
@@ -164,7 +156,7 @@ class AIFeedbackServiceTest {
 	}
 
 	@Test
-	void previewReview_retriesAsUpdateWhenConcurrentInsertRacesTheSummary() {
+	void autoReviewAndSave_retriesAsUpdateWhenConcurrentInsertRacesTheSummary() {
 		ResearchGroupGuidelines guidelines = readyGuidelines();
 		when(guidelinesRepository.findById(researchGroupId)).thenReturn(Optional.of(guidelines));
 
@@ -188,9 +180,8 @@ class AIFeedbackServiceTest {
 				candidate -> candidate != concurrentlyInserted)))
 				.thenThrow(new org.springframework.dao.DataIntegrityViolationException("duplicate key"));
 
-		AIPreviewResponseDTO response = service.previewReview(thesis, ReviewType.PROPOSAL);
+		service.autoReviewAndSave(thesis, ReviewType.PROPOSAL);
 
-		assertThat(response.score()).isEqualTo(90);
 		// The retry updates the row the concurrent run just inserted rather than failing.
 		verify(reviewSummaryRepository).save(concurrentlyInserted);
 		assertThat(concurrentlyInserted.getScore()).isEqualTo(90);

--- a/server/src/test/java/de/tum/cit/aet/thesis/feedback/service/AIFeedbackServiceTest.java
+++ b/server/src/test/java/de/tum/cit/aet/thesis/feedback/service/AIFeedbackServiceTest.java
@@ -23,8 +23,10 @@ import de.tum.cit.aet.thesis.feedback.repository.AIReviewSummaryRepository;
 import de.tum.cit.aet.thesis.feedback.repository.ResearchGroupGuidelinesRepository;
 import de.tum.cit.aet.thesis.feedback.service.reviewer.ReviewType;
 import de.tum.cit.aet.thesis.proposal.entity.ThesisProposal;
+import de.tum.cit.aet.thesis.proposal.repository.ThesisProposalRepository;
 import de.tum.cit.aet.thesis.thesis.entity.Thesis;
 import de.tum.cit.aet.thesis.thesis.entity.ThesisFile;
+import de.tum.cit.aet.thesis.thesis.repository.ThesisFileRepository;
 import de.tum.cit.aet.thesis.thesis.service.ThesisService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -55,6 +57,12 @@ class AIFeedbackServiceTest {
 	private AIReviewSummaryRepository reviewSummaryRepository;
 
 	@Mock
+	private ThesisProposalRepository proposalRepository;
+
+	@Mock
+	private ThesisFileRepository thesisFileRepository;
+
+	@Mock
 	private Thesis thesis;
 
 	private AIFeedbackService service;
@@ -63,7 +71,8 @@ class AIFeedbackServiceTest {
 
 	@BeforeEach
 	void setUp() {
-		service = new AIFeedbackService(reviewService, thesisService, guidelinesRepository, reviewSummaryRepository);
+		service = new AIFeedbackService(reviewService, thesisService, guidelinesRepository, reviewSummaryRepository,
+				proposalRepository, thesisFileRepository);
 
 		ResearchGroup researchGroup = new ResearchGroup();
 		researchGroup.setId(researchGroupId);
@@ -190,6 +199,7 @@ class AIFeedbackServiceTest {
 		when(guidelinesRepository.findById(researchGroupId)).thenReturn(Optional.of(guidelines));
 
 		ThesisProposal proposal = org.mockito.Mockito.mock(ThesisProposal.class);
+		when(proposal.getId()).thenReturn(UUID.randomUUID());
 		when(thesis.getProposals()).thenReturn(List.of(proposal));
 		Resource pdfResource = new ByteArrayResource("pdf".getBytes());
 		when(thesisService.getProposalFile(proposal)).thenReturn(pdfResource);
@@ -198,6 +208,7 @@ class AIFeedbackServiceTest {
 				.thenReturn(new ReviewResultDTO(AssessmentCategory.GOOD, 95, "Nothing to flag.", List.of()));
 		UUID thesisId = UUID.randomUUID();
 		when(thesis.getId()).thenReturn(thesisId);
+		when(proposalRepository.findFirstByThesisIdOrderByCreatedAtDesc(thesisId)).thenReturn(Optional.of(proposal));
 		when(reviewSummaryRepository.findByThesisIdAndType(thesisId, ReviewType.PROPOSAL)).thenReturn(Optional.empty());
 
 		Thesis result = service.autoReviewAndSave(thesis, ReviewType.PROPOSAL);
@@ -226,6 +237,7 @@ class AIFeedbackServiceTest {
 				.thenReturn(new ReviewResultDTO(AssessmentCategory.GOOD, 95, "Nothing to flag.", List.of()));
 		UUID thesisId = UUID.randomUUID();
 		when(thesis.getId()).thenReturn(thesisId);
+		when(proposalRepository.findFirstByThesisIdOrderByCreatedAtDesc(thesisId)).thenReturn(Optional.of(proposal));
 		when(reviewSummaryRepository.findByThesisIdAndType(thesisId, ReviewType.PROPOSAL)).thenReturn(Optional.empty());
 
 		service.autoReviewAndSave(thesis, ReviewType.PROPOSAL);
@@ -253,6 +265,8 @@ class AIFeedbackServiceTest {
 				.thenReturn(new ReviewResultDTO(AssessmentCategory.ACCEPTABLE, 70, "Some gaps.", List.of()));
 		UUID thesisId = UUID.randomUUID();
 		when(thesis.getId()).thenReturn(thesisId);
+		when(thesisFileRepository.findFirstByThesisIdAndTypeOrderByUploadedAtDesc(thesisId, "THESIS"))
+				.thenReturn(Optional.of(thesisFile));
 		when(reviewSummaryRepository.findByThesisIdAndType(thesisId, ReviewType.THESIS)).thenReturn(Optional.empty());
 
 		service.autoReviewAndSave(thesis, ReviewType.THESIS);
@@ -260,6 +274,34 @@ class AIFeedbackServiceTest {
 		ArgumentCaptor<AIReviewSummary> savedSummary = ArgumentCaptor.forClass(AIReviewSummary.class);
 		verify(reviewSummaryRepository).save(savedSummary.capture());
 		assertThat(savedSummary.getValue().getDocumentVersionId()).isEqualTo(fileId);
+	}
+
+	@Test
+	void autoReviewAndSave_discardsTheSummaryWhenANewerDocumentWasUploadedDuringTheReview() {
+		ResearchGroupGuidelines guidelines = readyGuidelines();
+		when(guidelinesRepository.findById(researchGroupId)).thenReturn(Optional.of(guidelines));
+
+		ThesisProposal reviewedProposal = org.mockito.Mockito.mock(ThesisProposal.class);
+		when(reviewedProposal.getId()).thenReturn(UUID.randomUUID());
+		when(thesis.getProposals()).thenReturn(List.of(reviewedProposal));
+		Resource pdfResource = new ByteArrayResource("pdf".getBytes());
+		when(thesisService.getProposalFile(reviewedProposal)).thenReturn(pdfResource);
+
+		when(reviewService.review(eq(pdfResource), eq(ReviewType.PROPOSAL), eq(guidelines.getStructuredGuidelines())))
+				.thenReturn(new ReviewResultDTO(AssessmentCategory.NEEDS_WORK, 40, "Stale read.", List.of()));
+		UUID thesisId = UUID.randomUUID();
+		when(thesis.getId()).thenReturn(thesisId);
+
+		// The student uploaded a new proposal while the pipeline was running, and a review of that
+		// one may already have written the summary — this run's result is about the old revision.
+		ThesisProposal newerProposal = org.mockito.Mockito.mock(ThesisProposal.class);
+		when(newerProposal.getId()).thenReturn(UUID.randomUUID());
+		when(proposalRepository.findFirstByThesisIdOrderByCreatedAtDesc(thesisId))
+				.thenReturn(Optional.of(newerProposal));
+
+		service.autoReviewAndSave(thesis, ReviewType.PROPOSAL);
+
+		verify(reviewSummaryRepository, never()).save(any());
 	}
 
 	@Test
@@ -278,6 +320,7 @@ class AIFeedbackServiceTest {
 				.thenReturn(new ReviewResultDTO(AssessmentCategory.GOOD, 90, "All good.", List.of()));
 		UUID thesisId = UUID.randomUUID();
 		when(thesis.getId()).thenReturn(thesisId);
+		when(proposalRepository.findFirstByThesisIdOrderByCreatedAtDesc(thesisId)).thenReturn(Optional.of(proposal));
 
 		// Both this run and a concurrent one see no existing row first...
 		AIReviewSummary concurrentlyInserted = new AIReviewSummary();

--- a/server/src/test/java/de/tum/cit/aet/thesis/feedback/service/AIFeedbackServiceTest.java
+++ b/server/src/test/java/de/tum/cit/aet/thesis/feedback/service/AIFeedbackServiceTest.java
@@ -24,6 +24,7 @@ import de.tum.cit.aet.thesis.feedback.repository.ResearchGroupGuidelinesReposito
 import de.tum.cit.aet.thesis.feedback.service.reviewer.ReviewType;
 import de.tum.cit.aet.thesis.proposal.entity.ThesisProposal;
 import de.tum.cit.aet.thesis.thesis.entity.Thesis;
+import de.tum.cit.aet.thesis.thesis.entity.ThesisFile;
 import de.tum.cit.aet.thesis.thesis.service.ThesisService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -210,11 +211,65 @@ class AIFeedbackServiceTest {
 	}
 
 	@Test
+	void autoReviewAndSave_recordsTheReviewedProposalVersionOnTheSummary() {
+		ResearchGroupGuidelines guidelines = readyGuidelines();
+		when(guidelinesRepository.findById(researchGroupId)).thenReturn(Optional.of(guidelines));
+
+		UUID proposalId = UUID.randomUUID();
+		ThesisProposal proposal = org.mockito.Mockito.mock(ThesisProposal.class);
+		when(proposal.getId()).thenReturn(proposalId);
+		when(thesis.getProposals()).thenReturn(List.of(proposal));
+		Resource pdfResource = new ByteArrayResource("pdf".getBytes());
+		when(thesisService.getProposalFile(proposal)).thenReturn(pdfResource);
+
+		when(reviewService.review(eq(pdfResource), eq(ReviewType.PROPOSAL), eq(guidelines.getStructuredGuidelines())))
+				.thenReturn(new ReviewResultDTO(AssessmentCategory.GOOD, 95, "Nothing to flag.", List.of()));
+		UUID thesisId = UUID.randomUUID();
+		when(thesis.getId()).thenReturn(thesisId);
+		when(reviewSummaryRepository.findByThesisIdAndType(thesisId, ReviewType.PROPOSAL)).thenReturn(Optional.empty());
+
+		service.autoReviewAndSave(thesis, ReviewType.PROPOSAL);
+
+		// Without the version the UI cannot tell this summary apart from one describing an older
+		// upload, and would keep showing the stale score as current.
+		ArgumentCaptor<AIReviewSummary> savedSummary = ArgumentCaptor.forClass(AIReviewSummary.class);
+		verify(reviewSummaryRepository).save(savedSummary.capture());
+		assertThat(savedSummary.getValue().getDocumentVersionId()).isEqualTo(proposalId);
+	}
+
+	@Test
+	void autoReviewAndSave_recordsTheReviewedThesisFileVersionOnTheSummary() {
+		ResearchGroupGuidelines guidelines = readyGuidelines();
+		when(guidelinesRepository.findById(researchGroupId)).thenReturn(Optional.of(guidelines));
+
+		UUID fileId = UUID.randomUUID();
+		ThesisFile thesisFile = org.mockito.Mockito.mock(ThesisFile.class);
+		when(thesisFile.getId()).thenReturn(fileId);
+		when(thesis.getLatestFile("THESIS")).thenReturn(Optional.of(thesisFile));
+		Resource pdfResource = new ByteArrayResource("pdf".getBytes());
+		when(thesisService.getThesisFile(thesisFile)).thenReturn(pdfResource);
+
+		when(reviewService.review(eq(pdfResource), eq(ReviewType.THESIS), eq(guidelines.getStructuredGuidelines())))
+				.thenReturn(new ReviewResultDTO(AssessmentCategory.ACCEPTABLE, 70, "Some gaps.", List.of()));
+		UUID thesisId = UUID.randomUUID();
+		when(thesis.getId()).thenReturn(thesisId);
+		when(reviewSummaryRepository.findByThesisIdAndType(thesisId, ReviewType.THESIS)).thenReturn(Optional.empty());
+
+		service.autoReviewAndSave(thesis, ReviewType.THESIS);
+
+		ArgumentCaptor<AIReviewSummary> savedSummary = ArgumentCaptor.forClass(AIReviewSummary.class);
+		verify(reviewSummaryRepository).save(savedSummary.capture());
+		assertThat(savedSummary.getValue().getDocumentVersionId()).isEqualTo(fileId);
+	}
+
+	@Test
 	void autoReviewAndSave_retriesAsUpdateWhenConcurrentInsertRacesTheSummary() {
 		ResearchGroupGuidelines guidelines = readyGuidelines();
 		when(guidelinesRepository.findById(researchGroupId)).thenReturn(Optional.of(guidelines));
 
+		UUID proposalId = UUID.randomUUID();
 		ThesisProposal proposal = org.mockito.Mockito.mock(ThesisProposal.class);
+		when(proposal.getId()).thenReturn(proposalId);
 		when(thesis.getProposals()).thenReturn(List.of(proposal));
 		Resource pdfResource = new ByteArrayResource("pdf".getBytes());
 		when(thesisService.getProposalFile(proposal)).thenReturn(pdfResource);
@@ -240,5 +295,6 @@ class AIFeedbackServiceTest {
 		verify(reviewSummaryRepository).save(concurrentlyInserted);
 		assertThat(concurrentlyInserted.getScore()).isEqualTo(90);
 		assertThat(concurrentlyInserted.getAssessment()).isEqualTo(AssessmentCategory.GOOD);
+		assertThat(concurrentlyInserted.getDocumentVersionId()).isEqualTo(proposalId);
 	}
 }

--- a/server/src/test/java/de/tum/cit/aet/thesis/feedback/service/AIFeedbackServiceTest.java
+++ b/server/src/test/java/de/tum/cit/aet/thesis/feedback/service/AIFeedbackServiceTest.java
@@ -3,6 +3,7 @@ package de.tum.cit.aet.thesis.feedback.service;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -13,10 +14,12 @@ import de.tum.cit.aet.thesis.core.group.entity.ResearchGroup;
 import de.tum.cit.aet.thesis.feedback.dto.AIPreviewResponseDTO;
 import de.tum.cit.aet.thesis.feedback.dto.AssessmentCategory;
 import de.tum.cit.aet.thesis.feedback.dto.ReviewResultDTO;
+import de.tum.cit.aet.thesis.feedback.entity.AIReviewSummary;
 import de.tum.cit.aet.thesis.feedback.entity.GuidelinesStatus;
 import de.tum.cit.aet.thesis.feedback.entity.ResearchGroupGuidelines;
 import de.tum.cit.aet.thesis.feedback.entity.jsonb.CategoryGuidelines;
 import de.tum.cit.aet.thesis.feedback.entity.jsonb.StructuredGuidelines;
+import de.tum.cit.aet.thesis.feedback.repository.AIReviewSummaryRepository;
 import de.tum.cit.aet.thesis.feedback.repository.ResearchGroupGuidelinesRepository;
 import de.tum.cit.aet.thesis.feedback.service.reviewer.ReviewType;
 import de.tum.cit.aet.thesis.proposal.entity.ThesisProposal;
@@ -25,6 +28,7 @@ import de.tum.cit.aet.thesis.thesis.service.ThesisService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.core.io.ByteArrayResource;
@@ -47,6 +51,9 @@ class AIFeedbackServiceTest {
 	private ResearchGroupGuidelinesRepository guidelinesRepository;
 
 	@Mock
+	private AIReviewSummaryRepository reviewSummaryRepository;
+
+	@Mock
 	private Thesis thesis;
 
 	private AIFeedbackService service;
@@ -55,7 +62,7 @@ class AIFeedbackServiceTest {
 
 	@BeforeEach
 	void setUp() {
-		service = new AIFeedbackService(reviewService, thesisService, guidelinesRepository);
+		service = new AIFeedbackService(reviewService, thesisService, guidelinesRepository, reviewSummaryRepository);
 
 		ResearchGroup researchGroup = new ResearchGroup();
 		researchGroup.setId(researchGroupId);
@@ -110,11 +117,49 @@ class AIFeedbackServiceTest {
 		when(thesisService.getProposalFile(proposal)).thenReturn(pdfResource);
 
 		when(reviewService.review(eq(pdfResource), eq(ReviewType.PROPOSAL), eq(guidelines.getStructuredGuidelines())))
-				.thenReturn(new ReviewResultDTO(AssessmentCategory.GOOD, "All good.", List.of()));
+				.thenReturn(new ReviewResultDTO(AssessmentCategory.GOOD, 90, "All good.", List.of()));
+		UUID thesisId = UUID.randomUUID();
+		when(thesis.getId()).thenReturn(thesisId);
+		when(reviewSummaryRepository.findByThesisIdAndType(thesisId, ReviewType.PROPOSAL)).thenReturn(Optional.empty());
 
 		AIPreviewResponseDTO response = service.previewReview(thesis, ReviewType.PROPOSAL);
 
 		assertThat(response.summary()).isEqualTo("All good.");
+		assertThat(response.score()).isEqualTo(90);
 		verify(reviewService).review(pdfResource, ReviewType.PROPOSAL, guidelines.getStructuredGuidelines());
+
+		ArgumentCaptor<AIReviewSummary> savedSummary = ArgumentCaptor.forClass(AIReviewSummary.class);
+		verify(reviewSummaryRepository).save(savedSummary.capture());
+		assertThat(savedSummary.getValue().getThesis()).isEqualTo(thesis);
+		assertThat(savedSummary.getValue().getType()).isEqualTo(ReviewType.PROPOSAL);
+		assertThat(savedSummary.getValue().getScore()).isEqualTo(90);
+		assertThat(savedSummary.getValue().getAssessment()).isEqualTo(AssessmentCategory.GOOD);
+		assertThat(savedSummary.getValue().getSummary()).isEqualTo("All good.");
+	}
+
+	@Test
+	void autoReviewAndSave_persistsReviewSummaryEvenWithNoActionableFindings() {
+		ResearchGroupGuidelines guidelines = readyGuidelines();
+		when(guidelinesRepository.findById(researchGroupId)).thenReturn(Optional.of(guidelines));
+
+		ThesisProposal proposal = org.mockito.Mockito.mock(ThesisProposal.class);
+		when(thesis.getProposals()).thenReturn(List.of(proposal));
+		Resource pdfResource = new ByteArrayResource("pdf".getBytes());
+		when(thesisService.getProposalFile(proposal)).thenReturn(pdfResource);
+
+		when(reviewService.review(eq(pdfResource), eq(ReviewType.PROPOSAL), eq(guidelines.getStructuredGuidelines())))
+				.thenReturn(new ReviewResultDTO(AssessmentCategory.GOOD, 95, "Nothing to flag.", List.of()));
+		UUID thesisId = UUID.randomUUID();
+		when(thesis.getId()).thenReturn(thesisId);
+		when(reviewSummaryRepository.findByThesisIdAndType(thesisId, ReviewType.PROPOSAL)).thenReturn(Optional.empty());
+
+		Thesis result = service.autoReviewAndSave(thesis, ReviewType.PROPOSAL);
+
+		assertThat(result).isSameAs(thesis);
+		verify(thesisService, never()).requestChanges(any(), any(), anyList(), any());
+
+		ArgumentCaptor<AIReviewSummary> savedSummary = ArgumentCaptor.forClass(AIReviewSummary.class);
+		verify(reviewSummaryRepository).save(savedSummary.capture());
+		assertThat(savedSummary.getValue().getScore()).isEqualTo(95);
 	}
 }

--- a/server/src/test/java/de/tum/cit/aet/thesis/feedback/service/AIFeedbackServiceTest.java
+++ b/server/src/test/java/de/tum/cit/aet/thesis/feedback/service/AIFeedbackServiceTest.java
@@ -130,6 +130,60 @@ class AIFeedbackServiceTest {
 	}
 
 	@Test
+	void previewReview_treatsNullScoreAsAbsent() {
+		ResearchGroupGuidelines guidelines = readyGuidelines();
+		when(guidelinesRepository.findById(researchGroupId)).thenReturn(Optional.of(guidelines));
+
+		ThesisProposal proposal = org.mockito.Mockito.mock(ThesisProposal.class);
+		when(thesis.getProposals()).thenReturn(List.of(proposal));
+		Resource pdfResource = new ByteArrayResource("pdf".getBytes());
+		when(thesisService.getProposalFile(proposal)).thenReturn(pdfResource);
+
+		when(reviewService.review(eq(pdfResource), eq(ReviewType.PROPOSAL), eq(guidelines.getStructuredGuidelines())))
+				.thenReturn(new ReviewResultDTO(AssessmentCategory.GOOD, null, "All good.", List.of()));
+
+		AIPreviewResponseDTO response = service.previewReview(thesis, ReviewType.PROPOSAL);
+
+		assertThat(response.score()).isNull();
+	}
+
+	@Test
+	void previewReview_nullsOutNegativeScore() {
+		ResearchGroupGuidelines guidelines = readyGuidelines();
+		when(guidelinesRepository.findById(researchGroupId)).thenReturn(Optional.of(guidelines));
+
+		ThesisProposal proposal = org.mockito.Mockito.mock(ThesisProposal.class);
+		when(thesis.getProposals()).thenReturn(List.of(proposal));
+		Resource pdfResource = new ByteArrayResource("pdf".getBytes());
+		when(thesisService.getProposalFile(proposal)).thenReturn(pdfResource);
+
+		when(reviewService.review(eq(pdfResource), eq(ReviewType.PROPOSAL), eq(guidelines.getStructuredGuidelines())))
+				.thenReturn(new ReviewResultDTO(AssessmentCategory.GOOD, -5, "All good.", List.of()));
+
+		AIPreviewResponseDTO response = service.previewReview(thesis, ReviewType.PROPOSAL);
+
+		assertThat(response.score()).isNull();
+	}
+
+	@Test
+	void previewReview_nullsOutScoreAboveMax() {
+		ResearchGroupGuidelines guidelines = readyGuidelines();
+		when(guidelinesRepository.findById(researchGroupId)).thenReturn(Optional.of(guidelines));
+
+		ThesisProposal proposal = org.mockito.Mockito.mock(ThesisProposal.class);
+		when(thesis.getProposals()).thenReturn(List.of(proposal));
+		Resource pdfResource = new ByteArrayResource("pdf".getBytes());
+		when(thesisService.getProposalFile(proposal)).thenReturn(pdfResource);
+
+		when(reviewService.review(eq(pdfResource), eq(ReviewType.PROPOSAL), eq(guidelines.getStructuredGuidelines())))
+				.thenReturn(new ReviewResultDTO(AssessmentCategory.GOOD, 150, "All good.", List.of()));
+
+		AIPreviewResponseDTO response = service.previewReview(thesis, ReviewType.PROPOSAL);
+
+		assertThat(response.score()).isNull();
+	}
+
+	@Test
 	void autoReviewAndSave_persistsReviewSummaryEvenWithNoActionableFindings() {
 		ResearchGroupGuidelines guidelines = readyGuidelines();
 		when(guidelinesRepository.findById(researchGroupId)).thenReturn(Optional.of(guidelines));

--- a/server/src/test/java/de/tum/cit/aet/thesis/feedback/service/AIFeedbackServiceTest.java
+++ b/server/src/test/java/de/tum/cit/aet/thesis/feedback/service/AIFeedbackServiceTest.java
@@ -162,4 +162,38 @@ class AIFeedbackServiceTest {
 		verify(reviewSummaryRepository).save(savedSummary.capture());
 		assertThat(savedSummary.getValue().getScore()).isEqualTo(95);
 	}
+
+	@Test
+	void previewReview_retriesAsUpdateWhenConcurrentInsertRacesTheSummary() {
+		ResearchGroupGuidelines guidelines = readyGuidelines();
+		when(guidelinesRepository.findById(researchGroupId)).thenReturn(Optional.of(guidelines));
+
+		ThesisProposal proposal = org.mockito.Mockito.mock(ThesisProposal.class);
+		when(thesis.getProposals()).thenReturn(List.of(proposal));
+		Resource pdfResource = new ByteArrayResource("pdf".getBytes());
+		when(thesisService.getProposalFile(proposal)).thenReturn(pdfResource);
+
+		when(reviewService.review(eq(pdfResource), eq(ReviewType.PROPOSAL), eq(guidelines.getStructuredGuidelines())))
+				.thenReturn(new ReviewResultDTO(AssessmentCategory.GOOD, 90, "All good.", List.of()));
+		UUID thesisId = UUID.randomUUID();
+		when(thesis.getId()).thenReturn(thesisId);
+
+		// Both this run and a concurrent one see no existing row first...
+		AIReviewSummary concurrentlyInserted = new AIReviewSummary();
+		when(reviewSummaryRepository.findByThesisIdAndType(thesisId, ReviewType.PROPOSAL))
+				.thenReturn(Optional.empty())
+				.thenReturn(Optional.of(concurrentlyInserted));
+		// ...so this run's own insert violates the (thesis_id, type) unique constraint.
+		when(reviewSummaryRepository.save(org.mockito.ArgumentMatchers.argThat(
+				candidate -> candidate != concurrentlyInserted)))
+				.thenThrow(new org.springframework.dao.DataIntegrityViolationException("duplicate key"));
+
+		AIPreviewResponseDTO response = service.previewReview(thesis, ReviewType.PROPOSAL);
+
+		assertThat(response.score()).isEqualTo(90);
+		// The retry updates the row the concurrent run just inserted rather than failing.
+		verify(reviewSummaryRepository).save(concurrentlyInserted);
+		assertThat(concurrentlyInserted.getScore()).isEqualTo(90);
+		assertThat(concurrentlyInserted.getAssessment()).isEqualTo(AssessmentCategory.GOOD);
+	}
 }

--- a/server/src/test/java/de/tum/cit/aet/thesis/feedback/service/ReviewServiceTest.java
+++ b/server/src/test/java/de/tum/cit/aet/thesis/feedback/service/ReviewServiceTest.java
@@ -82,7 +82,7 @@ public class ReviewServiceTest {
 		List<String> extractedText = List.of("Extracted text from PDF");
 		List<Media> extractedImages = List.of(new Media(MimeTypeUtils.IMAGE_PNG, URI.create("file:///proposal-template-page-1.png")));
 		IntermediateReviewResult intermediateReviewResult = new IntermediateReviewResult(List.of());
-		ReviewResultDTO expectedResult = new ReviewResultDTO(AssessmentCategory.ACCEPTABLE, "Overall assessment", List.of());
+		ReviewResultDTO expectedResult = new ReviewResultDTO(AssessmentCategory.ACCEPTABLE, 65, "Overall assessment", List.of());
 
 		when(pdfService.extractTextFromPdf(any(Resource.class))).thenReturn(extractedText);
 		when(pdfService.extractImagesFromPdf(any(Resource.class))).thenReturn(extractedImages);


### PR DESCRIPTION
## Summary

UI team feedback on the AI feedback overview/preview (from PR #1191) asked for:
* Error counts per category
* An "x/x addressed" indicator with clearer marking for fixed items
* Tooltips explaining what the severity/category/source badges mean
* An overall score

### Server
- `ReviewResultDTO` / `AIPreviewResponseDTO` gain a `score` (0-100) field. The merger LLM prompt (`Prompts.MERGER`, both PROPOSAL/THESIS variants) now instructs the model to also produce this score alongside its existing `GOOD`/`ACCEPTABLE`/`NEEDS_WORK` assessment.
- New `AIReviewSummary` entity + `AIReviewSummaryRepository`, migration `44_ai_review_summary.sql`: one row per `(thesis, reviewType)`, upserted by `AIFeedbackService` after every review run (student auto-review or supervisor preview) — independent of whether the resulting findings are actually saved.
- `Thesis` gains an `aiReviewSummaries` relation; `ThesisDto` exposes it as `aiReviewSummaries`.

### Client
- New `client/src/thesis/utils/feedbackLabels.ts`: shared colors/labels/short descriptions for severity, category, source, and assessment, replacing duplicated maps in the two components below.
- `ThesisFeedbackOverview.tsx`: per-category count badges, an "x/y addressed" counter with a progress bar, a green "Addressed" badge + dimmed/struck-through text for resolved rows, an "Overall Score" banner (when a review summary exists for that type), and tooltips on severity/category/source badges explaining what each means.
- `ThesisFeedbackRequestButton.tsx`: the AI preview alert now shows the score and a per-category count breakdown of drafts, plus a tooltip on the severity badge.

## Test plan
- [x] `cd server && ./gradlew test` — 1190/1190 passing (2 pre-existing skips)
- [x] `cd server && ./gradlew spotlessApply` — clean
- [x] `cd client && pnpm exec tsc --noEmit && pnpm exec eslint src/` — no errors (only pre-existing unrelated warnings)
- [x] Manual: student "Get AI Feedback" and supervisor "Generate with AI" flows show the score/category counts/tooltips as expected in a running instance

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * AI review results now display an overall score, assessment, and summary for proposals and theses.
  * Feedback overviews show progress for addressed items, category counts, severity, source, and resolution status.
  * Added helpful tooltips explaining feedback categories, severity levels, and generation sources.
  * Resolved feedback is visually marked with dimmed, struck-through text.
  * Category filters now use clearer, human-readable labels.
  * Review summaries are matched to the current document version to prevent outdated results from appearing.
  * AI review category counts now reflect AI-generated findings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->