### PR TITLE
Thesis abstract extractor fixes

### DIFF
--- a/server/src/main/java/de/tum/cit/aet/thesis/core/utility/AbstractExtractor.java
+++ b/server/src/main/java/de/tum/cit/aet/thesis/core/utility/AbstractExtractor.java
@@ -35,10 +35,19 @@ public final class AbstractExtractor {
 	private static final int MAX_PAGES = 12;
 	/** Baselines within this many points are considered the same text line. */
 	private static final float LINE_Y_TOLERANCE = 3f;
-	/** A new paragraph starts when the vertical gap exceeds this multiple of the median line gap. */
-	private static final float PARAGRAPH_GAP_FACTOR = 1.5f;
+	/**
+	 * A new paragraph starts when the vertical gap exceeds this multiple of the typical
+	 * (intra-paragraph) line gap. Kept modest so Word/LibreOffice abstracts that only add a
+	 * little extra space after each paragraph are still split.
+	 */
+	private static final float PARAGRAPH_GAP_FACTOR = 1.25f;
 	/** A line indented more than this many points past the left margin starts a new paragraph. */
 	private static final float PARAGRAPH_INDENT_MIN = 6f;
+	/**
+	 * A line whose visible width is below this fraction of the body's widest line is treated as
+	 * a short (likely final) line of a paragraph — used with sentence-end detection.
+	 */
+	private static final float SHORT_LINE_WIDTH_FACTOR = 0.85f;
 	/** Minimum plausible abstract length (characters) for a confident result. */
 	private static final int MIN_CONFIDENT_LENGTH = 50;
 	/** Maximum plausible abstract length (characters) for a confident result. */
@@ -60,6 +69,8 @@ public final class AbstractExtractor {
 	private static final Pattern CHAPTER_HEADING = Pattern.compile("^chapter\\s+\\d.*");
 	private static final Pattern TRAILING_PUNCTUATION = Pattern.compile("[\\s:.]+$");
 	private static final Pattern WHITESPACE = Pattern.compile("\\s+");
+	/** End of a sentence, optionally followed by a closing quote. */
+	private static final Pattern SENTENCE_END = Pattern.compile("[.!?]\u201d?\"?'?\\s*$");
 
 	private AbstractExtractor() {
 	}
@@ -86,7 +97,7 @@ public final class AbstractExtractor {
 	private record Chunk(String text, float startX, float endX, float y, float fontSize, int page) {
 	}
 
-	private record Line(String text, int page, float y, float startX, float fontSize) {
+	private record Line(String text, int page, float y, float startX, float endX, float fontSize) {
 	}
 
 	/**
@@ -197,7 +208,7 @@ public final class AbstractExtractor {
 
 		String collapsed = WHITESPACE.matcher(text.toString()).replaceAll(" ").trim();
 		return new Line(normalizeHyphens(collapsed), parts.getFirst().page(), parts.getFirst().y(),
-				parts.getFirst().startX(), maxFontSize);
+				parts.getFirst().startX(), parts.getLast().endX(), maxFontSize);
 	}
 
 	/**
@@ -299,19 +310,22 @@ public final class AbstractExtractor {
 			return paragraphs;
 		}
 
-		float medianGap = medianGap(body);
+		float typicalGap = typicalGap(body);
 		float leftMargin = leftMargin(body);
+		float maxLineWidth = maxLineWidth(body);
 		List<Line> current = new ArrayList<>();
 		current.add(body.getFirst());
 
 		for (int i = 1; i < body.size(); i++) {
 			Line prev = body.get(i - 1);
 			Line line = body.get(i);
-			// A paragraph break shows up either as extra vertical space or — in LaTeX-style
-			// abstracts with no inter-paragraph space — as a first-line indent.
+			// A paragraph break shows up as: extra vertical space; a first-line indent
+			// (LaTeX-style with no inter-paragraph space); or a short last line that ended a
+			// sentence while the next line starts a new one (flush-left, same leading).
 			boolean newParagraph = prev.page() != line.page()
-					|| (prev.y() - line.y()) > PARAGRAPH_GAP_FACTOR * medianGap
-					|| line.startX() - leftMargin > PARAGRAPH_INDENT_MIN;
+					|| (prev.y() - line.y()) > PARAGRAPH_GAP_FACTOR * typicalGap
+					|| line.startX() - leftMargin > PARAGRAPH_INDENT_MIN
+					|| isParagraphBreakByShortLine(prev, line, leftMargin, maxLineWidth);
 			if (newParagraph) {
 				paragraphs.add(joinLines(current));
 				current = new ArrayList<>();
@@ -333,7 +347,20 @@ public final class AbstractExtractor {
 		return min;
 	}
 
-	private static float medianGap(List<Line> body) {
+	private static float maxLineWidth(List<Line> body) {
+		float max = 0f;
+		for (Line line : body) {
+			max = Math.max(max, line.endX() - line.startX());
+		}
+		return max;
+	}
+
+	/**
+	 * Typical intra-paragraph line gap: a low percentile of observed gaps so large paragraph
+	 * gaps (common in abstracts with many short paragraphs) do not inflate the baseline the way
+	 * a plain median would.
+	 */
+	private static float typicalGap(List<Line> body) {
 		List<Float> gaps = new ArrayList<>();
 		for (int i = 1; i < body.size(); i++) {
 			float gap = body.get(i - 1).y() - body.get(i).y();
@@ -341,8 +368,37 @@ public final class AbstractExtractor {
 				gaps.add(gap);
 			}
 		}
+		if (gaps.isEmpty()) {
+			return 0f;
+		}
 		gaps.sort(Float::compare);
-		return median(gaps);
+		int index = Math.min(gaps.size() - 1, Math.max(0, (int) (gaps.size() * 0.25f)));
+		return gaps.get(index);
+	}
+
+	/**
+	 * Detects a paragraph break when layout uses neither extra vertical space nor a first-line
+	 * indent: the previous line ends a sentence and is visually short (not wrapping to the
+	 * column edge), while the next line starts with a capital letter.
+	 */
+	private static boolean isParagraphBreakByShortLine(
+			Line prev, Line next, float leftMargin, float maxLineWidth) {
+		if (maxLineWidth <= 0f) {
+			return false;
+		}
+		String prevText = prev.text().trim();
+		String nextText = next.text().trim();
+		if (prevText.isEmpty() || nextText.isEmpty()) {
+			return false;
+		}
+		if (!SENTENCE_END.matcher(prevText).find()) {
+			return false;
+		}
+		if (!Character.isUpperCase(nextText.codePointAt(0))) {
+			return false;
+		}
+		float prevWidth = prev.endX() - leftMargin;
+		return prevWidth < SHORT_LINE_WIDTH_FACTOR * maxLineWidth;
 	}
 
 	private static String joinLines(List<Line> lines) {

--- a/server/src/main/java/de/tum/cit/aet/thesis/core/utility/AbstractExtractor.java
+++ b/server/src/main/java/de/tum/cit/aet/thesis/core/utility/AbstractExtractor.java
@@ -215,8 +215,9 @@ public final class AbstractExtractor {
 	 * Normalizes the various hyphen encodings real PDFs use into a plain ASCII hyphen so the
 	 * line-join de-hyphenation works uniformly. Some thesis fonts map their hyphen glyph to the
 	 * Unicode replacement character (U+FFFD); Unicode hyphen / non-breaking hyphen are also
-	 * folded in. A soft hyphen (U+00AD) is only a real break when it ends a line — anywhere else
-	 * it is an invisible discretionary hyphen and is dropped.
+	 * folded in. Soft hyphens (U+00AD) become hard hyphens: trailing ones feed the line-join
+	 * rejoin logic, and mid-word ones preserve compounds such as {@code role-sensitive} that
+	 * LaTeX often encodes with a discretionary hyphen.
 	 *
 	 * <p>Package-private so the normalization can be unit-tested directly: the U+FFFD case cannot
 	 * be reproduced through a synthetic PDF because standard fonts drop the glyph at write time.
@@ -225,15 +226,11 @@ public final class AbstractExtractor {
 	 * @return the line text with hyphen encodings normalized
 	 */
 	static String normalizeHyphens(String text) {
-		String result = text
+		return text
 				.replace((char) 0xFFFD, '-')
 				.replace((char) 0x2010, '-')
-				.replace((char) 0x2011, '-');
-		String softHyphen = String.valueOf((char) 0x00AD);
-		if (result.endsWith(softHyphen)) {
-			result = result.substring(0, result.length() - 1) + "-";
-		}
-		return result.replace(softHyphen, "");
+				.replace((char) 0x2011, '-')
+				.replace((char) 0x00AD, '-');
 	}
 
 	private static int findHeadingIndex(List<Line> lines) {

--- a/server/src/main/java/de/tum/cit/aet/thesis/core/utility/AbstractExtractor.java
+++ b/server/src/main/java/de/tum/cit/aet/thesis/core/utility/AbstractExtractor.java
@@ -44,6 +44,12 @@ public final class AbstractExtractor {
 	/** A line indented more than this many points past the left margin starts a new paragraph. */
 	private static final float PARAGRAPH_INDENT_MIN = 6f;
 	/**
+	 * Modest extra leading (above the typical line gap) that, together with a short sentence-ending
+	 * line, marks a paragraph break. Real thesis templates often use only ~10–15% extra space
+	 * between paragraphs — below {@link #PARAGRAPH_GAP_FACTOR} alone.
+	 */
+	private static final float MODEST_PARAGRAPH_GAP_FACTOR = 1.08f;
+	/**
 	 * A line whose visible width is below this fraction of the body's widest line is treated as
 	 * a short (likely final) line of a paragraph — used with sentence-end detection.
 	 */
@@ -316,13 +322,17 @@ public final class AbstractExtractor {
 		for (int i = 1; i < body.size(); i++) {
 			Line prev = body.get(i - 1);
 			Line line = body.get(i);
-			// A paragraph break shows up as: extra vertical space; a first-line indent
-			// (LaTeX-style with no inter-paragraph space); or a short last line that ended a
-			// sentence while the next line starts a new one (flush-left, same leading).
+			float gap = prev.y() - line.y();
+			boolean clearGap = prev.page() == line.page() && gap > PARAGRAPH_GAP_FACTOR * typicalGap;
+			boolean modestGap = prev.page() == line.page() && gap > MODEST_PARAGRAPH_GAP_FACTOR * typicalGap;
+			// Break on a clear vertical gap, a first-line indent, or — for thesis templates that
+			// only add slight extra leading — a short sentence-ending line together with that
+			// modest gap. A short sentence wrap at normal leading alone is not enough (ragged
+			// right text can look identical without being a new paragraph).
 			boolean newParagraph = prev.page() != line.page()
-					|| (prev.y() - line.y()) > PARAGRAPH_GAP_FACTOR * typicalGap
+					|| clearGap
 					|| line.startX() - leftMargin > PARAGRAPH_INDENT_MIN
-					|| isParagraphBreakByShortLine(prev, line, leftMargin, maxLineWidth);
+					|| (modestGap && isParagraphBreakByShortLine(prev, line, leftMargin, maxLineWidth));
 			if (newParagraph) {
 				paragraphs.add(joinLines(current));
 				current = new ArrayList<>();
@@ -374,9 +384,10 @@ public final class AbstractExtractor {
 	}
 
 	/**
-	 * Detects a paragraph break when layout uses neither extra vertical space nor a first-line
-	 * indent: the previous line ends a sentence and is visually short (not wrapping to the
-	 * column edge), while the next line starts with a capital letter.
+	 * Candidate paragraph end: previous line ends a sentence and is visually short (not wrapping
+	 * to the column edge), while the next line starts with a capital letter. Must be combined
+	 * with a modest extra vertical gap by the caller — by itself this also matches ordinary
+	 * ragged-right sentence wraps.
 	 */
 	private static boolean isParagraphBreakByShortLine(
 			Line prev, Line next, float leftMargin, float maxLineWidth) {

--- a/server/src/test/java/de/tum/cit/aet/thesis/core/utility/AbstractExtractorTest.java
+++ b/server/src/test/java/de/tum/cit/aet/thesis/core/utility/AbstractExtractorTest.java
@@ -335,12 +335,15 @@ class AbstractExtractorTest {
 	}
 
 	@Test
-	void normalizeHyphens_softHyphenTrailingKeptOtherwiseDropped() {
+	void normalizeHyphens_softHyphenBecomesHardHyphen() {
 		String soft = String.valueOf((char) 0x00AD);
-		// A trailing soft hyphen marks a real break point and becomes a hyphen for the rejoin.
+		// Trailing soft hyphen becomes a hard hyphen so the line-join rejoin can remove it.
 		assertThat(AbstractExtractor.normalizeHyphens("auto" + soft)).isEqualTo("auto-");
-		// A soft hyphen that did not break is invisible and is dropped.
-		assertThat(AbstractExtractor.normalizeHyphens("co" + soft + "operate")).isEqualTo("cooperate");
+		// Mid-word soft hyphens preserve compounds (LaTeX discretionary hyphens in real theses).
+		assertThat(AbstractExtractor.normalizeHyphens("role" + soft + "sensitive"))
+				.isEqualTo("role-sensitive");
+		assertThat(AbstractExtractor.normalizeHyphens("guideline" + soft + "based"))
+				.isEqualTo("guideline-based");
 	}
 
 	@Test
@@ -357,6 +360,28 @@ class AbstractExtractorTest {
 		AbstractExtractor.Result result = AbstractExtractor.extract(pdf);
 
 		assertThat(result.html()).contains("automated").doesNotContain(soft);
+	}
+
+	@Test
+	void extract_midWordSoftHyphen_keepsCompoundHyphen() {
+		// Real theses often encode compounds with a soft hyphen mid-line; dropping it would glue
+		// the parts together ("rolesensitive"). It must become a visible hard hyphen.
+		String soft = String.valueOf((char) 0x00AD);
+		byte[] pdf = buildPdf(List.of(
+				new Line("Abstract", 14f, 780f),
+				new Line("We implement a role" + soft + "sensitive workflow with guideline"
+						+ soft + "based review for this evaluation.", 11f, 750f),
+				new Line("1 Introduction", 14f, 720f)
+		));
+
+		AbstractExtractor.Result result = AbstractExtractor.extract(pdf);
+
+		assertThat(result.html())
+				.contains("role-sensitive")
+				.contains("guideline-based")
+				.doesNotContain("rolesensitive")
+				.doesNotContain("guidelinebased")
+				.doesNotContain(soft);
 	}
 
 	/** Builds a PDF with one page per inner list of lines, for front-matter / page-window tests. */

--- a/server/src/test/java/de/tum/cit/aet/thesis/core/utility/AbstractExtractorTest.java
+++ b/server/src/test/java/de/tum/cit/aet/thesis/core/utility/AbstractExtractorTest.java
@@ -94,6 +94,64 @@ class AbstractExtractorTest {
 	}
 
 	@Test
+	void extract_modestParagraphGapWithoutIndent_areSplit() {
+		// Word-style abstracts often add only a little extra space between flush-left paragraphs
+		// (well under 1.5x the line gap). That modest gap must still start a new <p>.
+		byte[] pdf = buildPdf(List.of(
+				new Line("Abstract", 14f, 780f),
+				new Line("First paragraph runs across the full column width with plenty of words here.", 11f, 750f),
+				new Line("It continues onto a second line that also fills most of the column width.", 11f, 735f),
+				new Line("Second paragraph starts after only a modest vertical gap without indent.", 11f, 715f),
+				new Line("It also continues so the body has a clear typical intra-paragraph gap.", 11f, 700f),
+				new Line("1 Introduction", 14f, 670f)
+		));
+
+		AbstractExtractor.Result result = AbstractExtractor.extract(pdf);
+
+		assertThat(result.html())
+				.contains("<p>First paragraph runs across the full column width with plenty of words here. "
+						+ "It continues onto a second line that also fills most of the column width.</p>")
+				.contains("<p>Second paragraph starts after only a modest vertical gap without indent. "
+						+ "It also continues so the body has a clear typical intra-paragraph gap.</p>");
+	}
+
+	@Test
+	void extract_shortLastLineSentenceBreak_splitsFlushParagraphs() {
+		// Flush-left, identical leading: the only cue is a short last line that ends a sentence.
+		byte[] pdf = buildPdf(List.of(
+				new Line("Abstract", 14f, 780f),
+				new Line("This opening line is deliberately long so it defines the full column width clearly.", 11f, 750f),
+				new Line("Short end.", 11f, 735f),
+				new Line("Next paragraph begins here with a capital and should stand alone in HTML.", 11f, 720f),
+				new Line("1 Introduction", 14f, 690f)
+		));
+
+		AbstractExtractor.Result result = AbstractExtractor.extract(pdf);
+
+		assertThat(result.html())
+				.contains("<p>This opening line is deliberately long so it defines the full column width clearly. "
+						+ "Short end.</p>")
+				.contains("<p>Next paragraph begins here with a capital and should stand alone in HTML.</p>");
+	}
+
+	@Test
+	void extract_fullWidthSentenceWrap_doesNotSplitMidParagraph() {
+		// A mid-paragraph wrap after a period on a full-width line must stay in one <p>.
+		byte[] pdf = buildPdf(List.of(
+				new Line("Abstract", 14f, 780f),
+				new Line("We evaluate several baselines and report the main results. Additional", 11f, 750f),
+				new Line("detail about the setup follows in this same paragraph without a break.", 11f, 735f),
+				new Line("1 Introduction", 14f, 700f)
+		));
+
+		AbstractExtractor.Result result = AbstractExtractor.extract(pdf);
+
+		assertThat(result.html()).isEqualTo(
+				"<p>We evaluate several baselines and report the main results. Additional "
+						+ "detail about the setup follows in this same paragraph without a break.</p>");
+	}
+
+	@Test
 	void extract_clearAbstractWithIntroductionBoundary_returnsConfidentDehyphenatedParagraphs() {
 		byte[] pdf = buildPdf(List.of(
 				new Line("Abstract", 14f, 780f),

--- a/server/src/test/java/de/tum/cit/aet/thesis/core/utility/AbstractExtractorTest.java
+++ b/server/src/test/java/de/tum/cit/aet/thesis/core/utility/AbstractExtractorTest.java
@@ -116,14 +116,36 @@ class AbstractExtractorTest {
 	}
 
 	@Test
-	void extract_shortLastLineSentenceBreak_splitsFlushParagraphs() {
-		// Flush-left, identical leading: the only cue is a short last line that ends a sentence.
+	void extract_shortSentenceEndingWrap_doesNotSplitMidParagraph() {
+		// A ragged-right wrap can leave a short line that ends a sentence before a capitalized
+		// word that did not fit. At normal leading (no modest extra gap) that must stay one <p>.
 		byte[] pdf = buildPdf(List.of(
 				new Line("Abstract", 14f, 780f),
 				new Line("This opening line is deliberately long so it defines the full column width clearly.", 11f, 750f),
 				new Line("Short end.", 11f, 735f),
-				new Line("Next paragraph begins here with a capital and should stand alone in HTML.", 11f, 720f),
+				new Line("Next capitalized words continue the same paragraph at normal leading here.", 11f, 720f),
 				new Line("1 Introduction", 14f, 690f)
+		));
+
+		AbstractExtractor.Result result = AbstractExtractor.extract(pdf);
+
+		assertThat(result.html()).isEqualTo(
+				"<p>This opening line is deliberately long so it defines the full column width clearly. "
+						+ "Short end. Next capitalized words continue the same paragraph at normal "
+						+ "leading here.</p>");
+	}
+
+	@Test
+	void extract_shortLastLineWithModestGap_splitsParagraph() {
+		// Thesis templates often add only slight extra leading between flush-left paragraphs.
+		// A short sentence-ending line plus that modest gap must start a new <p>.
+		byte[] pdf = buildPdf(List.of(
+				new Line("Abstract", 14f, 780f),
+				new Line("This opening line is deliberately long so it defines the full column width clearly.", 11f, 750f),
+				new Line("Short end.", 11f, 735f),
+				// 17.5pt after a 15pt intra-paragraph gap (~1.17x) — modest, below the clear-gap factor.
+				new Line("Next paragraph begins here with a capital and should stand alone in HTML.", 11f, 717.5f),
+				new Line("1 Introduction", 14f, 685f)
 		));
 
 		AbstractExtractor.Result result = AbstractExtractor.extract(pdf);


### PR DESCRIPTION
## Summary
- Preserve real paragraph breaks when extracting abstracts from uploaded PDFs (modest gaps, short last lines, and indents).
- Keep compound hyphens that PDFs encode as soft hyphens (`role-sensitive` instead of `rolesensitive`), while still rejoining line-end hyphenation.

## Test plan
- [ ] Upload a multi-paragraph thesis PDF with a blank abstract and confirm paragraphs stay separated
- [ ] Confirm compounds like `role-sensitive` / `guideline-based` keep their hyphens
- [ ] Confirm line-broken words like `auto-` + `mated` still rejoin to `automated`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved PDF paragraph detection for modest vertical gaps and sentence-ending short lines.
  * Prevented ordinary full-width line wraps from being incorrectly split into separate paragraphs.
  * Standardized soft hyphens as visible hard hyphens, including within compound words.

* **Tests**
  * Added coverage for paragraph splitting, line-wrap preservation, and hyphen normalization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->